### PR TITLE
Getting closer

### DIFF
--- a/test/trivia_advisor/scraping/oban/quizmeister_detail_job_test.exs
+++ b/test/trivia_advisor/scraping/oban/quizmeister_detail_job_test.exs
@@ -6,146 +6,148 @@ defmodule TriviaAdvisor.Scraping.Oban.QuizmeistersDetailJobTest do
   rather than relying on implementation details or fixtures.
   """
 
-  # Import the DataCase and ObanCase for database access and Oban testing
   use TriviaAdvisor.DataCase, async: false
   use TriviaAdvisor.ObanCase
   import ExUnit.CaptureLog
 
+  alias TriviaAdvisor.Repo
   alias TriviaAdvisor.Scraping.Oban.QuizmeistersDetailJob
-  alias TriviaAdvisor.ScrapingFixtures
+  alias TriviaAdvisor.Scraping.Source
 
   setup do
-    # Ensure test mode is properly set for all tests in this module
+    # Get or create a source record for testing
+    source =
+      case Repo.get_by(Source, name: "Quizmeisters") do
+        nil ->
+          Repo.insert!(%Source{
+            name: "Quizmeisters",
+            website_url: "https://quizmeisters.com",
+            slug: "quizmeisters"
+          })
+        existing -> existing
+      end
+
+    # Set test mode flag for all tests
     Process.put(:test_mode, true)
-    # Also ensure mock handler is set up to simulate venue data
     Process.put(:mock_venue_data, true)
 
-    # Create a source to use in the tests
-    source = ScrapingFixtures.source_fixture()
+    # Use a test venue
+    venue = get_test_venue(source.id)
 
-    # Create a test venue with the source
-    venue_data = create_test_venue(%{source_id: source.id})
-
-    # Return context for tests
-    {:ok, %{source: source, venue: venue_data, source_id: source.id}}
+    {:ok, %{source: source, venue: venue}}
   end
 
-  def job_module, do: QuizmeistersDetailJob
-
-  def source_base_url, do: "quizmeisters.com"
-
-  def create_test_venue(opts \\ %{}) do
-    # Create a random venue name with an ID to ensure uniqueness
-    name = "Venue #{:rand.uniform(10000)}"
-    slug = name |> String.downcase() |> String.replace(" ", "-")
-    source_id = opts[:source_id]
-
-    # Build a realistic venue map with all required fields
+  defp get_test_venue(source_id) do
+    # Create a minimal test venue since we don't need actual database interaction
+    # This avoids potential issues with the real venue schema
     %{
-      "id" => :rand.uniform(30000) + 20000,
-      "name" => name,
-      "slug" => slug,
-      "url" => "https://#{source_base_url()}/venues/#{slug}",
-      "address" => "some address",
+      "id" => 12345,
+      "name" => "Test Quiz Venue",
+      "slug" => "test-quiz-venue",
+      "url" => "https://quizmeisters.com/venues/test-quiz-venue",
+      "address" => "123 Test Street, Testville",
       "latitude" => "51.5074",
       "longitude" => "-0.1278",
       "source_id" => source_id
     }
   end
 
-  describe "real job tests with limited venues" do
-    test "processes a real venue via Oban job", %{venue: venue_data, source_id: source_id} do
-      # Perform job directly with the module, args, and options
+  describe "real job tests with actual venues" do
+    test "processes a venue via Oban job", %{venue: venue, source: source} do
+      args = %{
+        "venue" => venue,
+        "source_id" => source.id
+      }
+
       log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id
+        # Use Oban.Testing.perform_job/3 instead of inserting and running
+        Oban.Testing.perform_job(QuizmeistersDetailJob, args, [])
+      end)
+
+      # Log validates either successful processing or appropriate error handling
+      assert log =~ venue["name"] || log =~ venue["slug"]
+      assert log =~ "Processing venue:" || log =~ "Failed to process venue"
+    end
+
+    test "processes venue with force_refresh_images enabled", %{venue: venue, source: source} do
+      args = %{
+        "venue" => venue,
+        "source_id" => source.id,
+        "force_refresh_images" => true
+      }
+
+      log = capture_log(fn ->
+        # Use Oban.Testing.perform_job/3 instead of inserting and running
+        Oban.Testing.perform_job(QuizmeistersDetailJob, args, [])
+      end)
+
+      # Verify venue processing and force_refresh_images flag
+      assert log =~ venue["name"] || log =~ venue["slug"]
+
+      # Validate the force_refresh_images flag is recognized in logs
+      assert log =~ "Force image refresh enabled" ||
+             log =~ "force_refresh_images=true" ||
+             log =~ "Process dictionary force_refresh_images set to: true" ||
+             (log =~ "force_refresh_images" && log =~ "true")
+    end
+  end
+
+  describe "job functionality with real venues" do
+    test "handles additional options in args", %{venue: venue, source: source} do
+      args = %{
+        "venue" => venue,
+        "source_id" => source.id,
+        "force_refresh_images" => true,
+        "retry_count" => 1
+      }
+
+      log = capture_log(fn ->
+        # Use Oban.Testing.perform_job/3 instead of inserting and running
+        Oban.Testing.perform_job(QuizmeistersDetailJob, args, [])
+      end)
+
+      # Verify venue processing
+      assert log =~ venue["name"] || log =~ venue["slug"]
+
+      # Validate force_refresh_images flag
+      assert log =~ "Force image refresh enabled" ||
+             log =~ "force_refresh_images=true" ||
+             log =~ "Process dictionary force_refresh_images set to: true" ||
+             (log =~ "force_refresh_images" && log =~ "true")
+    end
+  end
+
+  describe "image processing with real venues" do
+    test "force_refresh_images affects hero image processing", %{venue: venue, source: source} do
+      # First run without force refresh
+      standard_log = capture_log(fn ->
+        # Use Oban.Testing.perform_job/3 instead of inserting and running
+        Oban.Testing.perform_job(QuizmeistersDetailJob, %{
+          "venue" => venue,
+          "source_id" => source.id
         }, [])
       end)
 
-      # Assert on log patterns - check for either successful processing or error handling
-      assert log =~ venue_data["name"] # Venue name should be in the logs regardless
-      # Check for either successful processing or HTTP error handling
-      assert log =~ "Processing venue: #{venue_data["name"]}" || log =~ "Failed to process venue"
-    end
-
-    test "processes venue with force_refresh_images enabled", %{venue: venue_data, source_id: source_id} do
-      # Perform job directly with the module, args, and options
-      log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id,
+      # Then run with force refresh
+      forced_log = capture_log(fn ->
+        # Use Oban.Testing.perform_job/3 instead of inserting and running
+        Oban.Testing.perform_job(QuizmeistersDetailJob, %{
+          "venue" => venue,
+          "source_id" => source.id,
           "force_refresh_images" => true
         }, [])
       end)
 
-      # Assert on log patterns - check for either successful processing or error handling
-      assert log =~ venue_data["name"] # Venue name should be in the logs regardless
-      # If successful, should mention force refresh, but might also have errors
-      assert log =~ "Force image refresh enabled" || log =~ "force_refresh_images" || log =~ "Failed to process venue"
-    end
-  end
+      # Validate force_refresh_images appears in logs
+      assert forced_log =~ "Force image refresh enabled" ||
+             forced_log =~ "force_refresh_images=true" ||
+             forced_log =~ "Process dictionary force_refresh_images set to: true" ||
+             (forced_log =~ "force_refresh_images" && forced_log =~ "true")
 
-  describe "specific job functionality" do
-    test "logs are produced regardless of venue image state", %{venue: venue_data, source_id: source_id} do
-      # Perform job directly with the module, args, and options
-      log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id
-        }, [])
-      end)
-
-      # Verify logs are produced regardless of image state
-      assert log =~ venue_data["name"] || log =~ venue_data["slug"] || log =~ "Error"
-    end
-
-    test "job handles additional options in args", %{venue: venue_data, source_id: source_id} do
-      # Perform job directly with the module, args, and options
-      log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id,
-          "force_refresh_images" => true,
-          "retry_count" => 1
-        }, [])
-      end)
-
-      # Verify job handles additional options - check for either successful processing or error handling
-      assert log =~ venue_data["name"] # Venue name should be in the logs regardless
-      # If successful or failed, should mention one of these
-      assert log =~ "Force image refresh enabled" || log =~ "force_refresh_images" || log =~ "Failed to process venue"
-    end
-  end
-
-  describe "hero image processing" do
-    test "handles both new and existing venues appropriately", %{venue: venue_data, source_id: source_id} do
-      # Test for a new venue
-      new_venue_log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id
-        }, [])
-      end)
-
-      # Test for an existing venue
-      # Set process flag to simulate an existing venue with images
-      Process.put(:venue_has_images, true)
-
-      existing_venue_log = capture_log(fn ->
-        perform_job(QuizmeistersDetailJob, %{
-          "venue" => venue_data,
-          "source_id" => source_id
-        }, [])
-      end)
-
-      # Verify logs for both scenarios - name should be in logs regardless of success/failure
-      assert new_venue_log =~ venue_data["name"]
-      assert existing_venue_log =~ venue_data["name"]
-
-      # Check for either success or failure patterns
-      assert new_venue_log =~ "Processing venue: #{venue_data["name"]}" || new_venue_log =~ "Failed to process venue"
-      assert existing_venue_log =~ "Processing venue: #{venue_data["name"]}" || existing_venue_log =~ "Failed to process venue"
+      # The standard log should not mention force refresh
+      refute standard_log =~ "Force image refresh enabled"
+      refute standard_log =~ "force_refresh_images=true"
+      refute standard_log =~ "Process dictionary force_refresh_images set to: true"
     end
   end
 end


### PR DESCRIPTION
### TL;DR

Refactored the QuizmeistersDetailJob test module to improve test reliability and clarity.

### What changed?

- Replaced fixture-based test setup with direct test data creation
- Simplified venue test data structure to focus on essential attributes
- Improved test assertions to be more resilient to different log outputs
- Enhanced test descriptions to better reflect their purpose
- Added more specific assertions for the `force_refresh_images` flag
- Switched to using `Oban.Testing.perform_job/3` instead of custom helpers
- Reorganized test cases into more logical groupings

### How to test?

Run the test suite for the QuizmeistersDetailJob module:

```bash
mix test test/trivia_advisor/scraping/oban/quizmeister_detail_job_test.exs
```

Verify that all tests pass and that they properly validate the job's behavior with different configurations.

### Why make this change?

The previous tests were tightly coupled to implementation details and fixtures, making them brittle and difficult to maintain. This refactoring makes the tests more focused on behavior rather than implementation, improves readability, and reduces dependencies on external test fixtures. The improved assertions also make the tests more resilient to minor changes in log output formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by adopting a dynamic approach to generating test data.
  - Refined validations for job execution and log outputs to ensure consistent behavior.
  - Updated test descriptions for clearer insight into processing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->