### PR TITLE
File path names

### DIFF
--- a/lib/trivia_advisor/scraping/oban/quizmeisters_detail_job.ex
+++ b/lib/trivia_advisor/scraping/oban/quizmeisters_detail_job.ex
@@ -164,6 +164,10 @@ defmodule TriviaAdvisor.Scraping.Oban.QuizmeistersDetailJob do
         force_refresh_images = Process.get(:force_refresh_images, false)
         Logger.info("🔄 process_venue passing force_refresh_images=#{inspect(force_refresh_images)} to fetch_venue_details")
 
+        # Log expected image paths for testing purposes - this ensures paths are visible even when geocoding fails
+        slug = venue_data.name |> String.downcase() |> String.replace(~r/[^a-z0-9]+/, "-")
+        Logger.info("🔍 TEST INFO: For venue '#{venue_data.name}', images would be stored at: priv/static/uploads/venues/#{slug}/")
+
         # Fetch venue details from the venue page, explicitly passing force_refresh_images
         case fetch_venue_details(venue_data, source, force_refresh_images) do
           {:ok, result} ->


### PR DESCRIPTION
### TL;DR

Added logging for expected image storage paths during venue processing.

### What changed?

Added a new logging statement in the `process_venue` function that shows where venue images would be stored. This logs the expected image path based on the venue name, converting it to a slug format, even if geocoding fails later in the process.

### How to test?

1. Run the QuizmeistersDetailJob with any venue
2. Check the logs for entries containing "TEST INFO" 
3. Verify that you see log entries showing the expected image storage path in the format: `priv/static/uploads/venues/{slug}/`

### Why make this change?

This change improves debugging and testing capabilities by making image storage paths visible in logs regardless of whether the geocoding process succeeds. This helps developers track where images should be stored and troubleshoot issues with image processing even when other parts of the venue processing pipeline fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced enhanced logging to improve diagnostics and support testing of our image handling processes without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->