### PR TITLE
Fix warnings

### DIFF
--- a/lib/trivia_advisor/scraping/oban/quizmeisters_detail_job.ex
+++ b/lib/trivia_advisor/scraping/oban/quizmeisters_detail_job.ex
@@ -17,14 +17,6 @@ defmodule TriviaAdvisor.Scraping.Oban.QuizmeistersDetailJob do
   alias TriviaAdvisor.Scraping.Oban.GooglePlaceLookupJob
   alias TriviaAdvisor.Events.EventSource
 
-  # Increased timeout values to prevent hanging requests
-  @http_options [
-    follow_redirect: true,
-    timeout: 30_000,        # 30 seconds for connect timeout
-    recv_timeout: 30_000,   # 30 seconds for receive timeout
-    hackney: [pool: false]  # Don't use connection pooling for scrapers
-  ]
-
   @impl Oban.Worker
   def perform(%Oban.Job{id: job_id, args: %{"venue" => venue_data, "source_id" => source_id} = args}) do
     Logger.info("🔄 Processing venue: #{venue_data["name"]}")
@@ -212,7 +204,7 @@ defmodule TriviaAdvisor.Scraping.Oban.QuizmeistersDetailJob do
   defp find_trivia_day_from_fields(_), do: ""
 
   # Fetch venue details - adapted from Quizmeisters scraper
-  defp fetch_venue_details(venue_data, source, is_full_detail, force_refresh_images) do
+  defp fetch_venue_details(venue_data, source, _is_full_detail, force_refresh_images) do
     # CRITICAL FIX: Always create a test image in test mode
     # This needs to happen very early, before any potential errors
     if Process.get(:test_mode, false) && force_refresh_images do


### PR DESCRIPTION
### TL;DR

Removed unused HTTP options and fixed a parameter warning in the Quizmeisters detail job.

### What changed?

- Removed the unused `@http_options` constant that was defining timeout values for HTTP requests
- Fixed an unused parameter warning by adding an underscore prefix to the `_is_full_detail` parameter in the `fetch_venue_details/4` function

### How to test?

1. Run the Quizmeisters detail job to ensure it still functions correctly
2. Verify that no warnings are generated for unused variables when compiling
3. Confirm that HTTP requests still work properly without the removed options

### Why make this change?

This change improves code cleanliness by removing unused configuration and fixing a compiler warning. The HTTP options were likely moved elsewhere or are being set globally, making the module-specific definition redundant. Adding the underscore to the unused parameter follows Elixir best practices for indicating intentionally unused variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for retrieving venue details.
  - Simplified internal HTTP configurations to ensure a more efficient data retrieval flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->