### PR TITLE
deleting and re-adding both working

### DIFF
--- a/lib/trivia_advisor/events/event.ex
+++ b/lib/trivia_advisor/events/event.ex
@@ -37,22 +37,21 @@ defmodule TriviaAdvisor.Events.Event do
 
   @doc false
   def changeset(event, attrs) do
-    # Get the current hero image filename if it exists
+    # Log the hero image information for debugging
     current_image = event.hero_image && event.hero_image.file_name
+    has_hero_image = Map.has_key?(attrs, :hero_image)
+    Logger.info("🖼️ Event changeset - Current hero_image: #{inspect(current_image)}, attrs has hero_image: #{has_hero_image}")
 
-    # Get the new image filename if it exists
-    new_image = attrs[:hero_image] && attrs[:hero_image].filename
-
-    event
+    changeset = event
     |> cast(attrs, [:name, :venue_id, :day_of_week, :start_time, :frequency, :entry_fee_cents, :description, :performer_id])
-    |> maybe_cast_hero_image(attrs, current_image, new_image)
     |> validate_required([:name, :venue_id, :day_of_week, :start_time])
     |> foreign_key_constraint(:venue_id)
     |> foreign_key_constraint(:performer_id)
-  end
 
-  defp maybe_cast_hero_image(changeset, attrs, current_image, new_image) do
-    if current_image != new_image do
+    # Always cast hero_image attachments when they are provided
+    # This ensures Waffle processes them fully each time
+    if has_hero_image do
+      Logger.info("🖼️ Casting hero_image attachment")
       cast_attachments(changeset, attrs, [:hero_image])
     else
       changeset


### PR DESCRIPTION
### TL;DR

Improved hero image handling in event changesets to ensure proper processing of image attachments.

### What changed?

- Replaced conditional logic for hero image processing with a more reliable approach
- Added logging to track hero image processing for debugging purposes
- Simplified the changeset function by removing the separate `maybe_cast_hero_image` helper
- Now checking for the presence of a hero image in the attributes directly using `Map.has_key?`
- Always casting hero image attachments when provided to ensure Waffle processes them fully

### How to test?

1. Create a new event with a hero image and verify it uploads correctly
2. Edit an existing event with a hero image and confirm the image updates properly
3. Check logs for the new debugging information (look for entries with 🖼️ emoji)

### Why make this change?

The previous implementation had issues with hero image processing, potentially causing images not to be properly updated. This change ensures that Waffle always processes hero images when they're provided in the attributes, making the image upload and update process more reliable.