### PR TITLE
remove warnings

### DIFF
--- a/lib/trivia_advisor/sitemap.ex
+++ b/lib/trivia_advisor/sitemap.ex
@@ -240,10 +240,6 @@ defmodule TriviaAdvisor.Sitemap do
       # Log the final configuration details
       Logger.info("Sitemap config - S3Store, bucket: #{bucket}, path: #{sitemap_path}, region: #{region}")
 
-      # For S3, the sitemap_url should be the public URL of the S3 bucket
-      # This is where search engines will fetch the sitemap from
-      sitemap_host = "#{bucket}.fly.storage.tigris.dev"
-
       # Configure sitemap to store on S3
       [
         store: Sitemapper.S3Store,


### PR DESCRIPTION
### TL;DR

Removed unused `sitemap_host` variable in the sitemap configuration.

### What changed?

Removed the `sitemap_host` variable that was defined but not used in the S3 sitemap configuration. This variable was setting a host value based on the bucket name with the domain `fly.storage.tigris.dev`, but it wasn't being referenced in the actual configuration.

### How to test?

1. Verify that the sitemap generation still works correctly
2. Confirm that sitemaps are still properly stored in S3
3. Check that search engines can still access the sitemap from the correct URL

### Why make this change?

This change removes dead code that could cause confusion. The variable was defined but not used in the configuration, which might lead developers to think it's being utilized somewhere. Removing it makes the code cleaner and prevents potential misunderstandings about how the sitemap URL is being configured.