### PR TITLE
fixing broken pages

### DIFF
--- a/lib/trivia_advisor/uploaders/profile_image.ex
+++ b/lib/trivia_advisor/uploaders/profile_image.ex
@@ -57,6 +57,48 @@ defmodule TriviaAdvisor.Uploaders.ProfileImage do
     "#{version}_#{file_name}"
   end
 
+  # Override url/3 to safely handle nil values
+  def url(nil, _version, _opts), do: default_url(nil, nil)
+  def url(file_and_scope, version, opts) do
+    try do
+      # This matches what HeroImage does successfully
+      if Application.get_env(:waffle, :storage) == Waffle.Storage.S3 do
+        # Get the standard URL from Waffle
+        standard_url = super(file_and_scope, version, opts)
+
+        # Get bucket name from env var, with fallback
+        bucket = System.get_env("BUCKET_NAME") ||
+                 Application.get_env(:waffle, :bucket) ||
+                 "trivia-advisor"
+
+        # Get S3 configuration
+        s3_config = Application.get_env(:ex_aws, :s3, [])
+        host = case s3_config[:host] do
+          h when is_binary(h) -> h
+          _ -> "fly.storage.tigris.dev"
+        end
+
+        # Format path correctly for S3 (remove leading slash)
+        s3_path = if is_binary(standard_url) && String.starts_with?(standard_url, "/"),
+                  do: String.slice(standard_url, 1..-1//1),
+                  else: standard_url
+
+        # Construct the full S3 URL
+        if is_binary(s3_path) do
+          "https://#{bucket}.#{host}/#{s3_path}"
+        else
+          default_url(version, nil)
+        end
+      else
+        super(file_and_scope, version, opts)
+      end
+    rescue
+      e ->
+        Logger.error("Error in ProfileImage.url/3: #{Exception.message(e)}")
+        default_url(version, nil)
+    end
+  end
+
   # Provide a default URL if there hasn't been a file uploaded
   def default_url(_version, _scope) do
     "https://placehold.co/300x300/png?text=No+Image"

--- a/lib/trivia_advisor_web/live/venue/show.ex
+++ b/lib/trivia_advisor_web/live/venue/show.ex
@@ -382,10 +382,14 @@ defmodule TriviaAdvisorWeb.VenueLive.Show do
                     <div class="h-12 w-12 flex-shrink-0 overflow-hidden rounded-full">
                       <img
                         src={
-                          cond do
-                            is_map(event.performer.profile_image) -> ensure_full_url(TriviaAdvisor.Uploaders.ProfileImage.url({event.performer.profile_image, event.performer}))
-                            is_binary(event.performer.profile_image) -> event.performer.profile_image
-                            true -> nil
+                          try do
+                            cond do
+                              is_map(event.performer.profile_image) -> ensure_full_url(TriviaAdvisor.Uploaders.ProfileImage.url({event.performer.profile_image, event.performer}))
+                              is_binary(event.performer.profile_image) -> event.performer.profile_image
+                              true -> TriviaAdvisor.Uploaders.ProfileImage.default_url(nil, nil)
+                            end
+                          rescue
+                            _ -> TriviaAdvisor.Uploaders.ProfileImage.default_url(nil, nil)
                           end
                         }
                         alt={event.performer.name}


### PR DESCRIPTION
### TL;DR

Fixed profile image URL handling to properly display images and handle error cases gracefully.

### What changed?

- Overrode the `url/3` function in `ProfileImage` uploader to safely handle nil values
- Added proper S3 URL construction for profile images when using Waffle.Storage.S3
- Improved error handling with try/rescue blocks to prevent crashes
- Updated the venue show page to properly handle profile image display with error recovery
- Added fallback to default image URL when profile images can't be loaded

### How to test?

1. View a venue page with performers who have profile images
2. Check that profile images display correctly for performers with valid images
3. Verify that default placeholder images appear for performers without images
4. Test with S3 storage enabled to ensure proper URL construction
5. Intentionally cause an error (e.g., by providing invalid image data) to verify the fallback works

### Why make this change?

Profile images were not displaying correctly in some cases, particularly when using S3 storage. This change ensures consistent image display across the application and prevents crashes when image data is missing or invalid. The implementation follows the pattern already successfully used by the HeroImage uploader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced profile image handling so that a reliable default image is shown when image data is missing or invalid.
	- Improved error resilience during image retrieval, ensuring a stable and consistent viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->