### PR TITLE
Change to page titles

### DIFF
--- a/lib/trivia_advisor_web/components/layouts/root.html.heex
+++ b/lib/trivia_advisor_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="TriviaAdvisor" suffix=" · Phoenix Framework">
+    <.live_title default="QuizAdvisor" suffix=" · Pub Quiz">
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />


### PR DESCRIPTION
### TL;DR

Rebranded from TriviaAdvisor to QuizAdvisor and improved page titles for SEO.

### What changed?

- Changed the application name from "TriviaAdvisor" to "QuizAdvisor" in the page title
- Updated the suffix from "Phoenix Framework" to "Pub Quiz"
- Enhanced venue page titles to include city name and organizer information
- Added a `limit_title_length` helper function to ensure titles stay within 60 characters for SEO optimization
- Implemented smart truncation that preserves important information when titles exceed the character limit

### How to test?

1. Visit any venue page and verify the page title follows the new format: "[Venue Name] · in [City] by [Organizer] · QuizAdvisor"
2. Check that long titles are properly truncated with "..." while preserving the most important information
3. Verify the application name appears as "QuizAdvisor" throughout the site
4. Confirm the "Venue Not Found" page shows the updated title format

### Why make this change?

This change improves SEO by creating more descriptive and properly formatted page titles. Including the city and organizer information makes titles more informative for users and search engines. The 60-character limit ensures titles display properly in search results without being cut off. The rebranding to QuizAdvisor better reflects the application's focus on pub quizzes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated browser tab titles to reflect new branding ("TriviaAdvisor" is now "QuizAdvisor" with a refreshed suffix).
  - Enhanced venue pages with dynamic titles that now incorporate venue name, city, and event organizer details for improved identification and SEO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->