### PR TITLE
firest

### DIFF
--- a/lib/trivia_advisor_web/components/layouts/root.html.heex
+++ b/lib/trivia_advisor_web/components/layouts/root.html.heex
@@ -7,14 +7,22 @@
     <.live_title default="QuizAdvisor" suffix=" · Pub Quiz">
       {assigns[:page_title]}
     </.live_title>
-    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
-    </script>
+    
+    <!-- Open Graph tags for social sharing -->
+    <%= if assigns[:open_graph] do %>
+      <TriviaAdvisorWeb.Components.OpenGraphComponent.open_graph_tags {@open_graph} />
+    <% end %>
+    
+    <!-- JSON-LD structured data -->
     <%= if assigns[:json_ld_data] do %>
       <script type="application/ld+json">
         <%= Phoenix.HTML.raw(assigns[:json_ld_data]) %>
       </script>
     <% end %>
+    
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    </script>
   </head>
   <body class="bg-white">
     {@inner_content}

--- a/lib/trivia_advisor_web/components/open_graph_component.ex
+++ b/lib/trivia_advisor_web/components/open_graph_component.ex
@@ -1,0 +1,50 @@
+defmodule TriviaAdvisorWeb.Components.OpenGraphComponent do
+  use Phoenix.Component
+  require Logger
+
+  @doc """
+  Renders Open Graph meta tags for social media sharing.
+
+  ## Examples
+      <.open_graph_tags
+        type="event"
+        title="Pub Quiz at Venue Name"
+        description="Event description here"
+        image_url="https://example.com/image.jpg"
+        url="https://quizadvisor.com/venues/venue-slug"
+      />
+  """
+  attr :type, :string, default: "website"
+  attr :title, :string, required: true
+  attr :description, :string, required: true
+  attr :image_url, :string, required: true
+  attr :url, :string, required: true
+  attr :site_name, :string, default: "QuizAdvisor"
+
+  def open_graph_tags(assigns) do
+    # Ensure the image URL is a full URL
+    assigns = Map.update(assigns, :image_url, "", fn url ->
+      if is_binary(url) && String.starts_with?(url, "http"), do: url, else: url
+    end)
+
+    # Ensure the page URL is a full URL
+    assigns = Map.update(assigns, :url, "", fn url ->
+      if is_binary(url) && String.starts_with?(url, "http"), do: url, else: url
+    end)
+
+    ~H"""
+    <meta property="og:type" content={@type}>
+    <meta property="og:title" content={@title}>
+    <meta property="og:description" content={@description}>
+    <meta property="og:image" content={@image_url}>
+    <meta property="og:url" content={@url}>
+    <meta property="og:site_name" content={@site_name}>
+
+    <!-- Twitter Card tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content={@title}>
+    <meta name="twitter:description" content={@description}>
+    <meta name="twitter:image" content={@image_url}>
+    """
+  end
+end


### PR DESCRIPTION
### TL;DR

Added Open Graph meta tags for improved social media sharing of venue pages.

### What changed?

- Created a new `OpenGraphComponent` module that renders Open Graph and Twitter Card meta tags
- Updated the root layout to conditionally include Open Graph tags when available
- Enhanced the venue show page to generate appropriate Open Graph data including:
  - Title with venue name and city
  - Description based on venue details, quiz schedule, and organizer
  - Image URL from venue data
  - Canonical URL for the venue page
- Added fallback Open Graph data for "Venue Not Found" pages

### How to test?

1. Visit any venue page and view the page source
2. Verify that Open Graph meta tags are present in the `<head>` section
3. Try sharing a venue page on social media platforms to see the preview card
4. Test the "Venue Not Found" scenario to ensure fallback meta tags are displayed

### Why make this change?

This enhancement improves the appearance of shared venue pages on social media platforms like Facebook, Twitter, and LinkedIn. When users share venue pages, the posts will now display rich previews with relevant information about the pub quiz, making them more engaging and informative. This should increase click-through rates and help drive more traffic to the site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced social sharing and SEO capabilities with dynamic meta tag integration for structured data.
  - Venue pages now present improved meta descriptions that include event details, ensuring robust information display even in error scenarios.
  - The updates ensure a seamless experience when sharing content on social media, contributing to better visibility and engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->