### PR TITLE
filter by day

### DIFF
--- a/lib/debug/test_time_ago.exs
+++ b/lib/debug/test_time_ago.exs
@@ -1,5 +1,5 @@
 # Test script for time formatting functions
-# Run with: mix run test_time_ago.exs
+# Run with: mix run lib/debug/test_time_ago.exs
 
 # Import the FormatHelpers module
 alias TriviaAdvisorWeb.Helpers.FormatHelpers

--- a/lib/trivia_advisor_web/live/city/components/filter_bar.ex
+++ b/lib/trivia_advisor_web/live/city/components/filter_bar.ex
@@ -1,11 +1,11 @@
 defmodule TriviaAdvisorWeb.CityLive.Components.FilterBar do
   @moduledoc """
-  Filter component for city pages to handle radius selection and suburb filtering.
+  Filter component for city pages to handle radius selection, suburb filtering, and day of week filtering.
   """
   use TriviaAdvisorWeb, :live_component
 
   @doc """
-  Renders the filter bar with radius selector and suburb filters.
+  Renders the filter bar with radius selector, suburb filters, and day of week filters.
 
   ## Assigns
     * id - Component ID
@@ -13,6 +13,8 @@ defmodule TriviaAdvisorWeb.CityLive.Components.FilterBar do
     * radius_options - List of radius options as {label, value} tuples
     * selected_suburbs - List of selected suburb IDs
     * suburbs - List of available suburbs with their data
+    * selected_days - List of selected day of week numbers
+    * days_of_week - List of available days with their data
   """
   def render(assigns) do
     ~H"""
@@ -44,47 +46,104 @@ defmodule TriviaAdvisorWeb.CityLive.Components.FilterBar do
         <% end %>
       </p>
 
-      <%= if length(@suburbs) > 0 do %>
-        <div class="mb-6">
-          <div class="flex justify-between items-center mb-3">
-            <h3 class="text-sm font-medium text-gray-700">Filter by suburb:</h3>
-            <%= if length(@selected_suburbs) > 0 do %>
-              <button
-                phx-click="clear-suburbs"
-                class="text-sm text-indigo-600 hover:text-indigo-800"
-              >
-                Clear filters
-              </button>
-            <% end %>
-          </div>
-
-          <div class="flex flex-wrap gap-2">
-            <%= for suburb <- @suburbs do %>
-              <% is_selected = suburb.city.id in @selected_suburbs %>
-              <%= if is_selected do %>
+      <div class="flex flex-col gap-6 mb-6">
+        <%= if length(@days_of_week) > 0 do %>
+          <div class="w-full">
+            <div class="flex justify-between items-center mb-3">
+              <h3 class="text-sm font-medium text-gray-700">Filter by day:</h3>
+              <%= if length(@selected_days) > 0 do %>
                 <button
-                  phx-click="remove-suburb"
-                  phx-value-suburb-id={suburb.city.id}
-                  class="inline-flex items-center rounded-full bg-indigo-100 py-1.5 pl-3 pr-2 text-sm font-medium text-indigo-700 hover:bg-indigo-200"
+                  phx-click="clear-days"
+                  class="text-sm text-indigo-600 hover:text-indigo-800"
                 >
-                  <%= suburb.city.name %> (<%= suburb.venue_count %>)
-                  <span class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full text-indigo-500 hover:bg-indigo-200 hover:text-indigo-600">
-                    <svg class="h-2.5 w-2.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"></path>
-                    </svg>
-                  </span>
-                </button>
-              <% else %>
-                <button
-                  phx-click="select-suburb"
-                  phx-value-suburb-id={suburb.city.id}
-                  class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-200"
-                >
-                  <%= suburb.city.name %> (<%= suburb.venue_count %>)
+                  Clear day filters
                 </button>
               <% end %>
-            <% end %>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <%= for day <- @days_of_week do %>
+                <% is_selected = day.day_of_week in @selected_days %>
+                <%= if is_selected do %>
+                  <button
+                    phx-click="remove-day"
+                    phx-value-day={day.day_of_week}
+                    class="inline-flex items-center rounded-full bg-indigo-100 py-1.5 pl-3 pr-2 text-sm font-medium text-indigo-700 hover:bg-indigo-200"
+                  >
+                    <%= day.name %> (<%= day.venue_count %>)
+                    <span class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full text-indigo-500 hover:bg-indigo-200 hover:text-indigo-600">
+                      <svg class="h-2.5 w-2.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"></path>
+                      </svg>
+                    </span>
+                  </button>
+                <% else %>
+                  <button
+                    phx-click="select-day"
+                    phx-value-day={day.day_of_week}
+                    class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-200"
+                  >
+                    <%= day.name %> (<%= day.venue_count %>)
+                  </button>
+                <% end %>
+              <% end %>
+            </div>
           </div>
+        <% end %>
+
+        <%= if length(@suburbs) > 0 do %>
+          <div class="w-full">
+            <div class="flex justify-between items-center mb-3">
+              <h3 class="text-sm font-medium text-gray-700">Filter by suburb:</h3>
+              <%= if length(@selected_suburbs) > 0 do %>
+                <button
+                  phx-click="clear-suburbs"
+                  class="text-sm text-indigo-600 hover:text-indigo-800"
+                >
+                  Clear filters
+                </button>
+              <% end %>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <%= for suburb <- @suburbs do %>
+                <% is_selected = suburb.city.id in @selected_suburbs %>
+                <%= if is_selected do %>
+                  <button
+                    phx-click="remove-suburb"
+                    phx-value-suburb-id={suburb.city.id}
+                    class="inline-flex items-center rounded-full bg-indigo-100 py-1.5 pl-3 pr-2 text-sm font-medium text-indigo-700 hover:bg-indigo-200"
+                  >
+                    <%= suburb.city.name %> (<%= suburb.venue_count %>)
+                    <span class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full text-indigo-500 hover:bg-indigo-200 hover:text-indigo-600">
+                      <svg class="h-2.5 w-2.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"></path>
+                      </svg>
+                    </span>
+                  </button>
+                <% else %>
+                  <button
+                    phx-click="select-suburb"
+                    phx-value-suburb-id={suburb.city.id}
+                    class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-200"
+                  >
+                    <%= suburb.city.name %> (<%= suburb.venue_count %>)
+                  </button>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <%= if length(@selected_suburbs) > 0 || length(@selected_days) > 0 do %>
+        <div class="mb-6 flex justify-end">
+          <button
+            phx-click="clear-all-filters"
+            class="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+          >
+            Clear all filters
+          </button>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
### TL;DR

Added day of week filtering to the city page filter bar, allowing users to filter trivia venues by specific days.

### What changed?

- Added day of week filtering functionality to the filter bar component
- Moved the test script to `lib/debug/` directory for better organization
- Updated the filter bar UI to include day filters alongside suburb filters
- Added a "Clear all filters" button when any filters are active
- Implemented backend logic to filter venues by day of week
- Added helper functions to extract and filter venues by day of week
- Updated documentation to reflect new component functionality

### How to test?

1. Navigate to any city page
2. Use the new day of week filters to select specific days
3. Verify that venues are filtered correctly based on selected days
4. Test combinations of day and suburb filters
5. Verify that "Clear day filters" and "Clear all filters" buttons work as expected
6. Test the debug script with: `mix run lib/debug/test_time_ago.exs`

### Why make this change?

This enhancement improves the user experience by allowing visitors to find trivia venues that operate on specific days of the week. Users can now quickly filter venues based on their availability, making it easier to find suitable trivia nights without having to check each venue's schedule individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering by adding day-of-week selection alongside suburb and radius options.
	- Introduced clear filter options for day selections, allowing users to easily add, remove, or reset filters for a more tailored search experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->