### PR TITLE
first steps

### DIFF
--- a/github_issue.md
+++ b/github_issue.md
@@ -1,0 +1,89 @@
+# Replace Mock Data with Real Venue Data on Homepage
+
+## Background
+
+Currently, the homepage (`HomeLive.Index`) uses mock data for featured venues, popular cities, and upcoming events. This creates issues with maintenance and doesn't showcase actual data. We need to replace these mock functions with real database queries.
+
+## Objective
+
+Replace mock data on the homepage with real database queries showing the newest venues with events, ensuring diversity across cities and countries.
+
+## Detailed Requirements
+
+### 1. Featured Venues Query
+
+Create a query in `TriviaAdvisor.Locations` to:
+- Fetch newest venues that have scheduled events
+- Ensure diversity by selecting venues from different cities/countries
+- Sort by creation date (newest first)
+- Include all necessary fields (id, name, slug, rating, address, etc.)
+- Limit to a reasonable number for display (4-8)
+
+Example function signature:
+```elixir
+def get_featured_venues(limit \\ 4) do
+  # Query newest venues with events from diverse locations
+  # This should prioritize venues from different cities/countries
+end
+```
+
+### 2. Venue Card Component Enhancement
+
+Ensure the `VenueCard` component:
+- Handles real venue data structures robustly
+- Safely accesses fields using `Map.get/3` with defaults
+- Properly handles slugs similar to city slugs:
+  ```elixir
+  venue_slug = Map.get(venue, :slug) ||
+               String.downcase(venue.name) |> String.replace(~r/[^a-z0-9]+/, "-")
+  ```
+- Properly formats different time formats
+- Handles venue entry fees correctly
+- Displays ratings consistently
+
+### 3. Reuse Existing Helpers
+
+Leverage our existing helper modules:
+- `ImageHelpers` for venue images
+- `FormatHelpers` for formatting days/times
+- `CurrencyHelpers` for entry fee display
+- `LocalizationHelpers` for time zone handling
+
+### 4. Homepage Update
+
+Modify `HomeLive.Index`:
+- Replace `mock_featured_venues()` with call to the new query function
+- Consider caching results to minimize DB hits
+- Maintain consistent UI between mock and real data
+
+### 5. Testing Strategy
+
+Update `index_test.exs` to:
+- Test with real or fixed test data instead of mocks
+- Verify venue cards render correctly
+- Ensure all links work correctly
+- Validate slugs are properly generated
+- Test edge cases (venues without events, ratings, etc.)
+
+## Implementation Notes
+
+- Look at `CityLive.Show` for venue display patterns to maintain consistency
+- Ensure proper preloading to avoid N+1 queries
+- Consider adding filters/sorting options for future enhancement
+- Structure the query to be performant and cacheable
+
+## Acceptance Criteria
+
+- [ ] Homepage displays real venue data from database
+- [ ] Venues are displayed from different cities/countries when possible
+- [ ] Venue cards match design and include all required information
+- [ ] Venue slugs work correctly for navigation
+- [ ] No KeyErrors or crashes when handling venues with missing fields
+- [ ] Tests pass and properly validate functionality
+
+## Affected Files
+
+- `lib/trivia_advisor/locations.ex` - New query function
+- `lib/trivia_advisor_web/live/home/index.ex` - Update to use real data
+- `lib/trivia_advisor_web/components/ui/venue_card.ex` - Component enhancements
+- `test/trivia_advisor_web/live/home/index_test.exs` - Updated tests 

--- a/lib/trivia_advisor_web/components/ui/venue_card.ex.bak
+++ b/lib/trivia_advisor_web/components/ui/venue_card.ex.bak
@@ -8,7 +8,7 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
     <div class="venue-card flex flex-col overflow-hidden rounded-lg border bg-white shadow-sm transition hover:shadow-md">
       <div class="relative h-48 overflow-hidden">
         <img
-          src={get_venue_image_url(assigns.venue)}
+          src={get_hero_image(assigns.venue)}
           alt={Map.get(assigns.venue, :name, "Venue")}
           class="h-full w-full object-cover"
         />
@@ -47,26 +47,15 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
           <%= Map.get(assigns.venue, :description, "Join us for trivia nights!") %>
         </p>
 
-        <!-- City and Country (replacing ratings) -->
+        <!-- City and Country info instead of rating -->
         <div class="mt-auto flex items-center">
-          <svg class="mr-1 h-4 w-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M1 2.75A.75.75 0 011.75 2h10.5a.75.75 0 010 1.5H12v13.75a.75.75 0 01-.75.75h-1.5a.75.75 0 01-.75-.75v-2.5h-2v2.5a.75.75 0 01-.75.75h-1.5a.75.75 0 01-.75-.75v-2.5h-2v2.5a.75.75 0 01-.75.75h-1.5a.75.75 0 01-.75-.75V3.5h-.25A.75.75 0 011 2.75zM4 5.5a.5.5 0 01.5-.5h1a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-1a.5.5 0 01-.5-.5v-1zM4.5 9a.5.5 0 00-.5.5v1a.5.5 0 00.5.5h1a.5.5 0 00.5-.5v-1a.5.5 0 00-.5-.5h-1zM8 5.5a.5.5 0 01.5-.5h1a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-1a.5.5 0 01-.5-.5v-1zM8.5 9a.5.5 0 00-.5.5v1a.5.5 0 00.5.5h1a.5.5 0 00.5-.5v-1a.5.5 0 00-.5-.5h-1zM14.25 6a.75.75 0 00-.75.75V17a1 1 0 001 1h3.75a.75.75 0 000-1.5H18v-9h.25a.75.75 0 000-1.5h-4zm.5 3.5a.5.5 0 01.5-.5h1a.5.5 0 01.5.5v1a.5.5 0 01-.5.5h-1a.5.5 0 01-.5-.5v-1zm.5 3.5a.5.5 0 00-.5.5v1a.5.5 0 00.5.5h1a.5.5 0 00.5-.5v-1a.5.5 0 00-.5-.5h-1z" clip-rule="evenodd" />
+          <svg class="mr-1 h-4 w-4 text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z" clip-rule="evenodd" />
           </svg>
           <span class="text-sm text-gray-600">
-            <%= display_city_and_country(assigns.venue) %>
+            <%= get_venue_city(assigns.venue) %>, <%= get_venue_country_name(assigns.venue) %>
           </span>
         </div>
-
-        <!-- Commented out rating stars section
-        <div class="mt-auto flex items-center">
-          <div class="flex">
-            <%= render_rating_stars(assigns.venue) %>
-          </div>
-          <span class="ml-1 text-sm text-gray-600">
-            <%= format_rating(assigns.venue) %>
-          </span>
-        </div>
-        -->
       </div>
     </div>
     """
@@ -152,82 +141,91 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
   end
 
   # Get venue image with fallback
-  defp get_venue_image_url(venue) do
+  defp get_hero_image(venue) do
     cond do
       Map.has_key?(venue, :hero_image_url) && venue.hero_image_url && venue.hero_image_url != "" ->
         venue.hero_image_url
 
-      true ->
-        # Directly call ImageHelpers without checking if exported
+      # Use image helper if available
+      function_exported?(ImageHelpers, :get_venue_image, 1) ->
         ImageHelpers.get_venue_image(venue)
-    end
-  end
 
-  # Render star rating based on venue rating
-  defp render_rating_stars(venue) do
-    rating = get_venue_rating(venue)
-
-    cond do
-      is_nil(rating) -> "★★★★★"
-      not is_number(rating) -> "★★★★★"
       true ->
-        full_stars = floor(rating)
-        half_star = if rating - full_stars >= 0.5, do: 1, else: 0
-        empty_stars = 5 - full_stars - half_star
-
-        full_star_html = String.duplicate("★", full_stars)
-        half_star_html = if half_star == 1, do: "★", else: ""
-        empty_star_html = String.duplicate("☆", empty_stars)
-
-        full_star_html <> half_star_html <> empty_star_html
+        # Default placeholder image
+        "https://images.unsplash.com/photo-1546622891-02c72c1537b6?q=80&w=2000"
     end
   end
 
-  # Get venue rating with fallback
-  defp get_venue_rating(venue) do
-    rating = Map.get(venue, :rating)
+  # Fix the format_price function to properly handle entry_fee_cents
+  defp format_price(entry_fee_cents, venue) do
+    # Log the values for debugging
+    IO.inspect(entry_fee_cents, label: "Entry fee cents param")
+    if is_map(venue), do: IO.inspect(Map.get(venue, :entry_fee_cents), label: "Venue.entry_fee_cents")
 
-    if is_number(rating), do: rating, else: nil
-  end
+    # First try to get the actual value from entry_fee_cents parameter
+    entry_fee = cond do
+      is_integer(entry_fee_cents) and entry_fee_cents > 0 ->
+        entry_fee_cents
 
-  # Format rating for display
-  defp format_rating(venue) do
-    rating = get_venue_rating(venue)
+      # If not, try to extract it directly from the venue map
+      is_map(venue) and Map.has_key?(venue, :entry_fee_cents) ->
+        fee = venue.entry_fee_cents
+        if is_integer(fee) and fee > 0, do: fee, else: nil
 
-    if is_number(rating) do
-      "#{:erlang.float_to_binary(rating, [decimals: 1])}"
-    else
-      "No ratings yet"
+      # Try string parsing if it's a string
+      is_binary(entry_fee_cents) ->
+        case Integer.parse(entry_fee_cents) do
+          {int_cents, _} when int_cents > 0 -> int_cents
+          _ -> nil
+        end
+
+      true -> nil
     end
-  end
 
-  # Helper functions for formatting
-  defp format_price(cents, venue) when not is_nil(cents) do
-    # Convert to integer to ensure proper handling
-    cents_int =
-      case cents do
-        cents when is_integer(cents) -> cents
-        cents when is_binary(cents) ->
-          case Integer.parse(cents) do
-            {int, _} -> int
-            :error -> 0
-          end
-        _ -> 0
-      end
+    # Log the resolved entry fee
+    IO.inspect(entry_fee, label: "Resolved entry fee")
 
-    if cents_int > 0 do
+    if entry_fee do
       # Get the appropriate currency for this venue
       country_code = get_venue_country_code(venue)
       currency_code = get_country_currency(country_code)
 
       # Create Money struct with proper currency and format it
-      money = Money.new(cents_int, currency_code)
+      money = Money.new(entry_fee, currency_code)
       Money.to_string(money)
     else
       "Free"
     end
   end
-  defp format_price(_, _), do: "Free"
+
+  # This is the clean version without debugging logs
+  defp format_price(entry_fee_cents, venue) do
+    entry_fee = cond do
+      is_integer(entry_fee_cents) and entry_fee_cents > 0 ->
+        entry_fee_cents
+
+      is_map(venue) and Map.has_key?(venue, :entry_fee_cents) ->
+        fee = venue.entry_fee_cents
+        if is_integer(fee) and fee > 0, do: fee, else: nil
+
+      is_binary(entry_fee_cents) ->
+        case Integer.parse(entry_fee_cents) do
+          {int_cents, _} when int_cents > 0 -> int_cents
+          _ -> nil
+        end
+
+      true -> nil
+    end
+
+    if entry_fee do
+      country_code = get_venue_country_code(venue)
+      currency_code = get_country_currency(country_code)
+      money = Money.new(entry_fee, currency_code)
+      Money.to_string(money)
+    else
+      "Free"
+    end
+  end
 
   # Helper to get venue's country code
   defp get_venue_country_code(venue) do
@@ -302,15 +300,29 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
     LocalizationHelpers.format_localized_time(time, country)
   end
 
-  # New function to display city and country
-  defp display_city_and_country(venue) do
-    city_name = if has_city?(venue), do: venue.city.name, else: nil
-    country_name = if has_country?(venue), do: venue.city.country.name, else: nil
-
+  # Get venue's country name
+  defp get_venue_country_name(venue) do
     cond do
-      city_name && country_name -> "#{city_name}, #{country_name}"
-      city_name -> city_name
-      true -> "Location TBD"
+      # If venue has loaded city with country association
+      has_country?(venue) ->
+        venue.city.country.name
+
+      # Try to get country name using country code
+      code = get_venue_country_code(venue) ->
+        country_data = Countries.get(code)
+        if country_data, do: country_data.name, else: "United Kingdom"
+
+      true -> "United Kingdom" # Default if not found
+    end
+  end
+
+  # Get venue's city name
+  defp get_venue_city(venue) do
+    cond do
+      has_city?(venue) ->
+        venue.city.name
+      true ->
+        "Unknown Location"
     end
   end
 end

--- a/lib/trivia_advisor_web/components/ui/venue_card.ex.new
+++ b/lib/trivia_advisor_web/components/ui/venue_card.ex.new
@@ -1,0 +1,159 @@
+defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
+  use TriviaAdvisorWeb, :html
+  alias TriviaAdvisorWeb.Helpers.LocalizationHelpers
+  alias TriviaAdvisorWeb.Helpers.ImageHelpers
+
+  def venue_card(assigns) do
+    ~H"""
+    <div class="venue-card flex flex-col overflow-hidden rounded-lg border bg-white shadow-sm transition hover:shadow-md">
+      <div class="relative h-48 overflow-hidden">
+        <img
+          src={get_hero_image(assigns.venue)}
+          alt={Map.get(assigns.venue, :name, "Venue")}
+          class="h-full w-full object-cover"
+        />
+
+        <!-- Entry fee badge -->
+        <div class="absolute right-2 top-2 rounded-full bg-indigo-600 px-2 py-1 text-xs font-medium text-white">
+          <%= format_price(Map.get(assigns.venue, :entry_fee_cents), assigns.venue) %>
+        </div>
+      </div>
+
+      <div class="flex flex-1 flex-col p-4">
+        <h3 class="mb-1 text-lg font-semibold text-gray-900 line-clamp-1">
+          <a href={~p"/venues/#{get_venue_slug(assigns.venue)}"} class="hover:text-indigo-600">
+            <%= Map.get(assigns.venue, :name, "Venue") %>
+          </a>
+        </h3>
+
+        <div class="mb-2 flex items-center text-sm text-gray-600">
+          <svg class="mr-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z" clip-rule="evenodd" />
+          </svg>
+          <span class="truncate"><%= get_venue_address(assigns.venue) %></span>
+        </div>
+
+        <div class="mb-3 flex items-center text-sm text-gray-600">
+          <svg class="mr-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z" clip-rule="evenodd" />
+          </svg>
+          <span>
+            <%= format_day(get_venue_day_of_week(assigns.venue)) %> at <%= format_localized_time(get_venue_time(assigns.venue), get_venue_country(assigns.venue)) %>
+          </span>
+        </div>
+
+        <!-- Description with line clamp -->
+        <p class="mb-4 flex-1 text-sm text-gray-600 line-clamp-3">
+          <%= Map.get(assigns.venue, :description, "Join us for trivia nights!") %>
+        </p>
+
+        <!-- City and Country info instead of rating -->
+        <div class="mt-auto flex items-center">
+          <svg class="mr-1 h-4 w-4 text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M9.69 18.933l.003.001C9.89 19.02 10 19 10 19s.11.02.308-.066l.002-.001.006-.003.018-.008a5.741 5.741 0 00.281-.14c.186-.096.446-.24.757-.433.62-.384 1.445-.966 2.274-1.765C15.302 14.988 17 12.493 17 9A7 7 0 103 9c0 3.492 1.698 5.988 3.355 7.584a13.731 13.731 0 002.273 1.765 11.842 11.842 0 00.976.544l.062.029.018.008.006.003zM10 11.25a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5z" clip-rule="evenodd" />
+          </svg>
+          <span class="text-sm text-gray-600">
+            <%= get_venue_city(assigns.venue) %>, <%= get_venue_country_name(assigns.venue) %>
+          </span>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # Safe helper to get venue slug or generate one from name
+  defp get_venue_slug(venue) do
+    slug = Map.get(venue, :slug)
+    if slug && slug != "", do: slug, else: create_slug_from_name(venue)
+  end
+
+  # Create a slug from venue name
+  defp create_slug_from_name(venue) do
+    name = Map.get(venue, :name, "venue")
+    id = Map.get(venue, :id, "unknown")
+
+    slug = name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+
+    if slug == "", do: id, else: slug
+  end
+
+  # Safe helper to get venue address
+  defp get_venue_address(venue) do
+    address = Map.get(venue, :address)
+    city_name = if has_city?(venue), do: venue.city.name, else: nil
+
+    cond do
+      address && city_name -> "#{address}, #{city_name}"
+      address -> address
+      city_name -> city_name
+      true -> "Location details coming soon"
+    end
+  end
+
+  # Check if venue has city data
+  defp has_city?(venue) do
+    Map.has_key?(venue, :city) &&
+    is_map(venue.city) &&
+    Map.has_key?(venue.city, :name) &&
+    is_binary(venue.city.name)
+  end
+
+  # Get venue day of week with fallback
+  defp get_venue_day_of_week(venue) do
+    cond do
+      Map.has_key?(venue, :day_of_week) && venue.day_of_week ->
+        venue.day_of_week
+
+      Map.has_key?(venue, :events) &&
+      !match?(%Ecto.Association.NotLoaded{}, venue.events) &&
+      venue.events &&
+      Enum.any?(venue.events) ->
+        event = List.first(venue.events)
+        Map.get(event, :day_of_week, 1)
+
+      true ->
+        1 # Default to Monday
+    end
+  end
+
+  # Get venue time with fallback
+  defp get_venue_time(venue) do
+    cond do
+      Map.has_key?(venue, :start_time) && venue.start_time && is_struct(venue.start_time, Time) ->
+        venue.start_time
+
+      Map.has_key?(venue, :start_time) && is_binary(venue.start_time) ->
+        venue.start_time
+
+      Map.has_key?(venue, :events) &&
+      !match?(%Ecto.Association.NotLoaded{}, venue.events) &&
+      venue.events &&
+      Enum.any?(venue.events) ->
+        event = List.first(venue.events)
+        Map.get(event, :start_time, ~T[19:00:00])
+
+      true ->
+        ~T[19:00:00] # Default to 7:00 PM
+    end
+  end
+
+  # Get venue image with fallback
+  defp get_hero_image(venue) do
+    cond do
+      Map.has_key?(venue, :hero_image_url) && venue.hero_image_url && venue.hero_image_url != "" ->
+        venue.hero_image_url
+
+      # Use image helper if available
+      function_exported?(ImageHelpers, :get_venue_image, 1) ->
+        ImageHelpers.get_venue_image(venue)
+
+      true ->
+        # Default placeholder image
+        "https://images.unsplash.com/photo-1546622891-02c72c1537b6?q=80&w=2000"
+    end
+  end
+
+  # Fix the format_price function to properly handle entry_fee_cents

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -4,12 +4,10 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    # In a real app, you would fetch this data from your database
-    # For now, we'll use mock data
-
+    # Fetch real data from database
     {:ok, assign(socket,
       page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",
-      featured_venues: mock_featured_venues(),
+      featured_venues: TriviaAdvisor.Locations.get_featured_venues(limit: 4),
       popular_cities: mock_popular_cities(),
       upcoming_events: mock_upcoming_events()
     )}
@@ -127,7 +125,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
               <span aria-hidden="true">→</span>
             </a>
           </div>
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" data-testid="featured-venues">
             <%= for venue <- @featured_venues do %>
               <VenueCard.venue_card venue={venue} />
             <% end %>
@@ -145,7 +143,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
               <span aria-hidden="true">→</span>
             </a>
           </div>
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" data-testid="popular-cities">
             <%= for city <- @popular_cities do %>
               <CityCard.city_card city={city} />
             <% end %>
@@ -163,7 +161,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
               <span aria-hidden="true">→</span>
             </a>
           </div>
-          <div class="overflow-hidden rounded-lg bg-white shadow">
+          <div class="overflow-hidden rounded-lg bg-white shadow" data-testid="upcoming-events">
             <div class="divide-y divide-gray-200">
               <%= for event <- @upcoming_events do %>
                 <div class="flex items-center gap-4 p-4 transition hover:bg-gray-50">
@@ -262,55 +260,6 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
   end
 
   # Mock data functions for demonstration
-  defp mock_featured_venues do
-    [
-      %{
-        id: "1",
-        name: "The Pub Quiz Champion",
-        address: "123 Main St, London",
-        day_of_week: 4, # Thursday
-        start_time: "7:30 PM",
-        entry_fee_cents: 500,
-        description: "Join us every Thursday for our legendary pub quiz. Six rounds of trivia, picture rounds, and music. Great prizes and a fun atmosphere!",
-        hero_image_url: "https://images.unsplash.com/photo-1546622891-02c72c1537b6?q=80&w=2000",
-        rating: 4.5
-      },
-      %{
-        id: "2",
-        name: "Quiz Night at The Scholar",
-        address: "456 High St, Manchester",
-        day_of_week: 2, # Tuesday
-        start_time: "8:00 PM",
-        entry_fee_cents: 300,
-        description: "Tuesday night is quiz night! Form teams of up to 6 people and test your knowledge across a variety of categories.",
-        hero_image_url: "https://images.unsplash.com/photo-1574096079513-d8259312b785?q=80&w=2000",
-        rating: 4.2
-      },
-      %{
-        id: "3",
-        name: "Brainiac Trivia",
-        address: "789 Park Lane, Edinburgh",
-        day_of_week: 3, # Wednesday
-        start_time: "7:00 PM",
-        entry_fee_cents: nil,
-        description: "Free entry! Join us for an evening of challenging questions and a chance to win bar tabs and other prizes!",
-        hero_image_url: "https://images.unsplash.com/photo-1566633806327-68e152aaf26d?q=80&w=2000",
-        rating: 4.8
-      },
-      %{
-        id: "4",
-        name: "The Knowledge Inn",
-        address: "321 River Road, Glasgow",
-        day_of_week: 1, # Monday
-        start_time: "8:30 PM",
-        entry_fee_cents: 200,
-        description: "Start your week with our Monday quiz night. Different themes each week with special food and drink offers for participants.",
-        hero_image_url: "https://images.unsplash.com/photo-1600431521340-491eca880813?q=80&w=2000",
-        rating: 4.0
-      }
-    ]
-  end
-
   defp mock_popular_cities do
     [
       %{

--- a/test/trivia_advisor_web/live/home/index_test.exs
+++ b/test/trivia_advisor_web/live/home/index_test.exs
@@ -1,0 +1,65 @@
+defmodule TriviaAdvisorWeb.HomeLive.IndexTest do
+  use TriviaAdvisorWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import TriviaAdvisor.LocationsFixtures
+
+  setup do
+    # Create a test country, city, and venue
+    country = country_fixture(%{code: "GB", name: "United Kingdom"})
+    city = city_fixture(%{country_id: country.id, name: "London"})
+
+    # Create a few test venues
+    venue1 = venue_fixture(%{
+      name: "Test Venue 1",
+      day_of_week: 4,
+      start_time: "7:30 PM",
+      entry_fee_cents: 500,
+      description: "Test venue description",
+      city_id: city.id,
+      rating: 4.5
+    })
+
+    venue2 = venue_fixture(%{
+      name: "Test Venue 2",
+      day_of_week: 2,
+      start_time: "8:00 PM",
+      entry_fee_cents: 300,
+      description: "Another test venue",
+      city_id: city.id,
+      rating: 3.8
+    })
+
+    %{venues: [venue1, venue2], city: city, country: country}
+  end
+
+  describe "Home page" do
+    test "renders featured venues, popular cities, and upcoming events", %{conn: conn, venues: [venue1, venue2]} do
+      {:ok, view, html} = live(conn, ~p"/")
+
+      # Test that the page loads with the right title
+      assert html =~ "TriviaAdvisor - Find the Best Pub Quizzes Near You"
+      assert html =~ "Find the Best Pub Quizzes Near You"
+
+      # Test that the page has the main sections
+      assert has_element?(view, "[data-testid='featured-venues']")
+      assert has_element?(view, "[data-testid='popular-cities']")
+      assert has_element?(view, "[data-testid='upcoming-events']")
+
+      # Test that venue cards are rendered properly
+      assert has_element?(view, ".venue-card")
+
+      # Test that at least one of the test venues appears on the page
+      assert html =~ venue1.name || html =~ venue2.name
+
+      # Test that venue slugs are generated
+      venue1_slug = String.downcase(venue1.name) |> String.replace(~r/[^a-z0-9]+/, "-")
+      venue2_slug = String.downcase(venue2.name) |> String.replace(~r/[^a-z0-9]+/, "-")
+
+      assert html =~ venue1_slug || html =~ venue2_slug
+
+      # Test that ratings are displayed
+      assert html =~ "★" # Check for star symbol in rating
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Replace mock venue data on the homepage with real database queries showing diverse venues with events.

### What changed?

- Added `get_featured_venues/1` function in `TriviaAdvisor.Locations` that fetches venues with events from diverse cities and countries
- Enhanced the `VenueCard` component to handle real venue data structures robustly with proper fallbacks
- Updated `HomeLive.Index` to use real venue data instead of mock data
- Added tests to verify the homepage displays real venue data correctly

### How to test?

1. Visit the homepage and verify that real venues are displayed in the featured venues section
2. Check that venues from different cities/countries are shown when available
3. Verify venue cards display all required information (name, address, day/time, etc.)
4. Confirm venue links work correctly with proper slugs
5. Run the new test suite with `mix test test/trivia_advisor_web/live/home/index_test.exs`

### Why make this change?

Using real venue data on the homepage improves maintenance and showcases actual data from our database. This change ensures users see the newest venues with events across diverse locations, providing a better representation of available trivia nights and improving the overall user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Homepage now displays real, diverse venue data sourced from the database, replacing mock data.
  - Venue cards enhanced to robustly display venue details, including address, entry fee, city, country, and improved slug generation.
- **Bug Fixes**
  - Improved handling of missing or incomplete venue data for a more reliable user experience.
- **Tests**
  - Updated and expanded homepage tests to validate rendering of real venue data and venue card functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->