### PR TITLE
adding live data for top cities

### DIFF
--- a/lib/trivia_advisor/test_fixtures.ex
+++ b/lib/trivia_advisor/test_fixtures.ex
@@ -1,0 +1,122 @@
+defmodule TriviaAdvisor.TestFixtures do
+  @moduledoc """
+  Contains mock data fixtures for testing and development.
+  These fixtures should only be used in test environment or during development.
+  """
+
+  @doc """
+  Returns mock featured venues for testing.
+  """
+  def mock_featured_venues do
+    [
+      %{
+        id: "1",
+        name: "Test Venue 1",
+        address: "123 Main Street",
+        city: %{name: "London", country: %{name: "United Kingdom", code: "GB"}},
+        rating: 4.5,
+        description: "Popular pub with weekly trivia nights and great atmosphere",
+        entry_fee_cents: 500,
+        day_of_week: 4,
+        start_time: ~T[19:30:00],
+        hero_image_url: "https://images.unsplash.com/photo-1560840881-4bbcd415a9ab?q=80&w=2000",
+        slug: "test-venue-1"
+      },
+      %{
+        id: "2",
+        name: "Test Venue 2",
+        address: "456 High Street",
+        city: %{name: "Manchester", country: %{name: "United Kingdom", code: "GB"}},
+        rating: 3.8,
+        description: "Specialized trivia venue with themed quiz nights",
+        entry_fee_cents: 300,
+        day_of_week: 2,
+        start_time: ~T[20:00:00],
+        hero_image_url: "https://images.unsplash.com/photo-1572116469696-31de0f17cc34?q=80&w=2000",
+        slug: "test-venue-2"
+      },
+      %{
+        id: "3",
+        name: "Brainy Bar",
+        address: "789 Park Avenue",
+        city: %{name: "Edinburgh", country: %{name: "United Kingdom", code: "GB"}},
+        rating: 4.2,
+        description: "Fun pub with challenging quiz questions and great prizes",
+        entry_fee_cents: 0,
+        day_of_week: 3,
+        start_time: ~T[19:00:00],
+        hero_image_url: "https://images.unsplash.com/photo-1583227122027-d2d360c66d3c?q=80&w=2000"
+      },
+      %{
+        id: "4",
+        name: "Trivia Tavern",
+        address: "101 River Road",
+        city: %{name: "Bristol", country: %{name: "United Kingdom", code: "GB"}},
+        rating: 4.0,
+        description: "Traditional pub with weekly general knowledge quizzes",
+        entry_fee_cents: 200,
+        day_of_week: 1,
+        start_time: ~T[20:30:00],
+        hero_image_url: "https://images.unsplash.com/photo-1546726747-421c6d69c929?q=80&w=2000"
+      }
+    ]
+  end
+
+  @doc """
+  Returns mock popular cities for testing.
+  """
+  def mock_popular_cities do
+    [
+      %{id: "1", name: "London", country_name: "United Kingdom", venue_count: 120, image_url: "https://test.com/london.jpg", slug: "london"},
+      %{id: "2", name: "New York", country_name: "United States", venue_count: 87, image_url: "https://test.com/ny.jpg", slug: "new-york"},
+      %{id: "3", name: "Sydney", country_name: "Australia", venue_count: 45, image_url: "https://test.com/sydney.jpg", slug: "sydney"},
+      %{id: "4", name: "Berlin", country_name: "Germany", venue_count: 35, image_url: "https://test.com/berlin.jpg", slug: "berlin"},
+      %{id: "5", name: "Dublin", country_name: "Ireland", venue_count: 30, image_url: "https://test.com/dublin.jpg", slug: "dublin"},
+      %{id: "6", name: "Toronto", country_name: "Canada", venue_count: 28, image_url: "https://test.com/toronto.jpg", slug: "toronto"}
+    ]
+  end
+
+  @doc """
+  Returns mock upcoming events for testing.
+  """
+  def mock_upcoming_events do
+    [
+      %{
+        name: "The Ultimate Pub Quiz",
+        venue_id: "1",
+        day: "Thursday",
+        date: "23",
+        time: "7:30 PM",
+        price: "$5",
+        free?: false
+      },
+      %{
+        name: "Geek Trivia Night",
+        venue_id: "2",
+        day: "Tuesday",
+        date: "28",
+        time: "8:00 PM",
+        price: "$3",
+        free?: false
+      },
+      %{
+        name: "Music & Movies Quiz",
+        venue_id: "3",
+        day: "Wednesday",
+        date: "29",
+        time: "7:00 PM",
+        price: "Free",
+        free?: true
+      },
+      %{
+        name: "General Knowledge Challenge",
+        venue_id: "4",
+        day: "Monday",
+        date: "27",
+        time: "8:30 PM",
+        price: "$2",
+        free?: false
+      }
+    ]
+  end
+end

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -1,22 +1,31 @@
 defmodule TriviaAdvisorWeb.HomeLive.Index do
   use TriviaAdvisorWeb, :live_view
   alias TriviaAdvisorWeb.Components.UI.{CitySearch, VenueCard, CityCard}
+  alias TriviaAdvisor.TestFixtures
 
   @impl true
   def mount(_params, _session, socket) do
-    # Conditionally use mock data in test environment to avoid HTTP requests
-    featured_venues =
+    # Use real data in production but mock data in test environment
+    {featured_venues, popular_cities, upcoming_events} =
       if Mix.env() == :test do
-        mock_featured_venues()
+        {
+          TestFixtures.mock_featured_venues(),
+          TestFixtures.mock_popular_cities(),
+          TestFixtures.mock_upcoming_events()
+        }
       else
-        TriviaAdvisor.Locations.get_featured_venues(limit: 4)
+        {
+          TriviaAdvisor.Locations.get_featured_venues(limit: 4),
+          TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true),
+          TestFixtures.mock_upcoming_events() # Keep this mock for now until we implement real events
+        }
       end
 
     {:ok, assign(socket,
       page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",
       featured_venues: featured_venues,
-      popular_cities: mock_popular_cities(),
-      upcoming_events: mock_upcoming_events()
+      popular_cities: popular_cities,
+      upcoming_events: upcoming_events
     )}
   end
 
@@ -264,131 +273,5 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
       </section>
     </div>
     """
-  end
-
-  # Mock data functions for demonstration
-  defp mock_popular_cities do
-    [
-      %{
-        id: "1",
-        name: "London",
-        country_name: "United Kingdom",
-        venue_count: 120,
-        image_url: "https://images.unsplash.com/photo-1533929736458-ca588d08c8be?q=80&w=2000",
-        slug: "london"
-      },
-      %{
-        id: "2",
-        name: "New York",
-        country_name: "United States",
-        venue_count: 87,
-        image_url: "https://images.unsplash.com/photo-1496442226666-8d4d0e62e6e9?q=80&w=2000",
-        slug: "new-york"
-      },
-      %{
-        id: "3",
-        name: "Sydney",
-        country_name: "Australia",
-        venue_count: 45,
-        image_url: "https://images.unsplash.com/photo-1506973035872-a4ec16b8e8d9?q=80&w=2000",
-        slug: "sydney"
-      }
-    ]
-  end
-
-  defp mock_upcoming_events do
-    [
-      %{
-        name: "The Ultimate Pub Quiz",
-        venue_id: "1",
-        day: "Thursday",
-        date: "23",
-        time: "7:30 PM",
-        price: "$5",
-        free?: false
-      },
-      %{
-        name: "Geek Trivia Night",
-        venue_id: "2",
-        day: "Tuesday",
-        date: "28",
-        time: "8:00 PM",
-        price: "$3",
-        free?: false
-      },
-      %{
-        name: "Music & Movies Quiz",
-        venue_id: "3",
-        day: "Wednesday",
-        date: "29",
-        time: "7:00 PM",
-        price: "Free",
-        free?: true
-      },
-      %{
-        name: "General Knowledge Challenge",
-        venue_id: "4",
-        day: "Monday",
-        date: "27",
-        time: "8:30 PM",
-        price: "$2",
-        free?: false
-      }
-    ]
-  end
-
-  defp mock_featured_venues do
-    [
-      %{
-        id: "1",
-        name: "Test Venue 1",
-        address: "123 Main Street",
-        city: %{name: "London", country: %{name: "United Kingdom", code: "GB"}},
-        rating: 4.5,
-        description: "Popular pub with weekly trivia nights and great atmosphere",
-        entry_fee_cents: 500,
-        day_of_week: 4,
-        start_time: ~T[19:30:00],
-        hero_image_url: "https://images.unsplash.com/photo-1560840881-4bbcd415a9ab?q=80&w=2000",
-        slug: "test-venue-1"
-      },
-      %{
-        id: "2",
-        name: "Test Venue 2",
-        address: "456 High Street",
-        city: %{name: "Manchester", country: %{name: "United Kingdom", code: "GB"}},
-        rating: 3.8,
-        description: "Specialized trivia venue with themed quiz nights",
-        entry_fee_cents: 300,
-        day_of_week: 2,
-        start_time: ~T[20:00:00],
-        hero_image_url: "https://images.unsplash.com/photo-1572116469696-31de0f17cc34?q=80&w=2000",
-        slug: "test-venue-2"
-      },
-      %{
-        id: "3",
-        name: "Brainy Bar",
-        address: "789 Park Avenue",
-        city: %{name: "Edinburgh", country: %{name: "United Kingdom", code: "GB"}},
-        rating: 4.2,
-        description: "Fun pub with challenging quiz questions and great prizes",
-        entry_fee_cents: 0,
-        day_of_week: 3,
-        start_time: ~T[19:00:00],
-        hero_image_url: "https://images.unsplash.com/photo-1583227122027-d2d360c66d3c?q=80&w=2000"
-      },
-      %{
-        id: "4",
-        name: "Trivia Tavern",
-        address: "101 River Road",
-        city: %{name: "Bristol", country: %{name: "United Kingdom", code: "GB"}},
-        rating: 4.0,
-        description: "Traditional pub with weekly general knowledge quizzes",
-        entry_fee_cents: 200,
-        day_of_week: 1,
-        start_time: ~T[20:30:00],
-        hero_image_url: "https://images.unsplash.com/photo-1546726747-421c6d69c929?q=80&w=2000"
-      }
-    ]
   end
 end


### PR DESCRIPTION
### TL;DR

Added geographic clustering for popular cities and centralized test fixtures.

### What changed?

- Implemented `get_popular_cities` function with geographic clustering to prevent nearby suburbs from being counted separately
- Created a new `TestFixtures` module to centralize mock data for testing and development
- Updated the homepage to use real popular cities data in production instead of mock data
- Moved mock data from the homepage live view to the new fixtures module

### How to test?

1. Run the application and verify that the homepage displays popular cities with proper clustering
2. Check that cities within 50km of each other are properly grouped, with the larger city absorbing the venue counts
3. Verify that the "Popular Cities" section shows cities from diverse countries
4. Confirm that each city displays with the correct venue count and image

### Why make this change?

The previous implementation showed cities individually, which led to suburbs appearing separately from their main cities. This geographic clustering ensures that major metropolitan areas are represented properly by combining nearby locations. Additionally, centralizing test fixtures improves code organization and maintainability by removing duplicated mock data from view modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve and display popular cities based on venue density, with geographic clustering and country diversity options.
- **Chores**
  - Introduced a centralized set of mock data for featured venues, popular cities, and upcoming events to support testing and development environments.
- **Refactor**
  - Unified and streamlined the way featured venues, popular cities, and upcoming events are assigned and mocked on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->