### PR TITLE
fixes

### DIFF
--- a/lib/trivia_advisor/test_fixtures.ex
+++ b/lib/trivia_advisor/test_fixtures.ex
@@ -67,12 +67,12 @@ defmodule TriviaAdvisor.TestFixtures do
   """
   def mock_popular_cities do
     [
-      %{id: "1", name: "London", country_name: "United Kingdom", venue_count: 120, image_url: "https://test.com/london.jpg", slug: "london"},
-      %{id: "2", name: "New York", country_name: "United States", venue_count: 87, image_url: "https://test.com/ny.jpg", slug: "new-york"},
-      %{id: "3", name: "Sydney", country_name: "Australia", venue_count: 45, image_url: "https://test.com/sydney.jpg", slug: "sydney"},
-      %{id: "4", name: "Berlin", country_name: "Germany", venue_count: 35, image_url: "https://test.com/berlin.jpg", slug: "berlin"},
-      %{id: "5", name: "Dublin", country_name: "Ireland", venue_count: 30, image_url: "https://test.com/dublin.jpg", slug: "dublin"},
-      %{id: "6", name: "Toronto", country_name: "Canada", venue_count: 28, image_url: "https://test.com/toronto.jpg", slug: "toronto"}
+      %{id: "1", name: "London", country_name: "United Kingdom", venue_count: 120, image_url: "https://images.unsplash.com/photo-1513635269975-59663e0ac1ad", slug: "london"},
+      %{id: "2", name: "New York", country_name: "United States", venue_count: 87, image_url: "https://images.unsplash.com/photo-1496442226666-8d4d0e62e6e9", slug: "new-york"},
+      %{id: "3", name: "Sydney", country_name: "Australia", venue_count: 45, image_url: "https://images.unsplash.com/photo-1527915676329-fd5ec8a44d4b", slug: "sydney"},
+      %{id: "4", name: "Berlin", country_name: "Germany", venue_count: 35, image_url: "https://images.unsplash.com/photo-1599946347371-68eb71b16afc", slug: "berlin"},
+      %{id: "5", name: "Dublin", country_name: "Ireland", venue_count: 30, image_url: "https://images.unsplash.com/photo-1566096653784-304ec4a5d2c7", slug: "dublin"},
+      %{id: "6", name: "Toronto", country_name: "Canada", venue_count: 28, image_url: "https://images.unsplash.com/photo-1517935706615-2717063c2225", slug: "toronto"}
     ]
   end
 


### PR DESCRIPTION
### TL;DR

Improved city image loading by using stored galleries instead of external API calls

### What changed?

- Refactored `add_city_images` function to use stored Unsplash galleries from the database instead of making external API calls
- Implemented random image selection from each city's gallery to ensure variety in displayed images
- Removed the now-unnecessary `extract_image_url` helper function
- Updated test fixtures with realistic Unsplash image URLs

### How to test?

1. Navigate to pages that display city images (homepage, city listings)
2. Verify that city images load correctly
3. Refresh the page multiple times to confirm that different images appear for cities with multiple gallery images
4. Check that performance is improved due to elimination of external API calls

### Why make this change?

This change improves performance by eliminating external API calls to Unsplash when displaying city images. Instead, it uses pre-stored galleries from the database, reducing latency and potential API rate limit issues. The implementation also adds variety by randomly selecting images from each city's gallery rather than always using the same one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how city images are retrieved by selecting a random image from each city's gallery stored in the database, instead of relying on an external service.
- **Tests**
  - Updated test fixtures to use real Unsplash image URLs for city image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->