### PR TITLE
latest venues

### DIFF
--- a/lib/trivia_advisor_web/components/ui/venue_card.ex
+++ b/lib/trivia_advisor_web/components/ui/venue_card.ex
@@ -45,6 +45,14 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
           </span>
         </div>
 
+        <!-- Added creation date -->
+        <div class="mb-2 flex items-center text-sm text-gray-600">
+          <svg class="mr-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.75 2a.75.75 0 01.75.75V4h7V2.75a.75.75 0 011.5 0V4h.25A2.75 2.75 0 0118 6.75v8.5A2.75 2.75 0 0115.25 18H4.75A2.75 2.75 0 012 15.25v-8.5A2.75 2.75 0 014.75 4H5V2.75A.75.75 0 015.75 2zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd" />
+          </svg>
+          <span>Added <%= format_creation_date(assigns.venue) %></span>
+        </div>
+
         <!-- Price information -->
         <div class="mb-2 flex items-center text-sm text-gray-600">
           <svg class="mr-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -426,5 +434,17 @@ defmodule TriviaAdvisorWeb.Components.UI.VenueCard do
     !match?(%Ecto.Association.NotLoaded{}, venue.events) &&
     is_list(venue.events) &&
     length(venue.events) > 0
+  end
+
+  # Format creation date using the time_ago_in_words helper
+  @spec format_creation_date(map()) :: String.t()
+  defp format_creation_date(venue) do
+    inserted_at = Map.get(venue, :inserted_at)
+
+    if inserted_at do
+      TriviaAdvisorWeb.Helpers.FormatHelpers.time_ago_in_words(inserted_at)
+    else
+      "recently"
+    end
   end
 end

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -9,7 +9,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
     popular_cities = TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true)
 
     {:ok, assign(socket,
-      page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",
+      page_title: "QuizAdvisor - Find the Best Pub Quizzes Near You",
       featured_venues: featured_venues,
       popular_cities: popular_cities
     )}
@@ -84,7 +84,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
       <!-- How It Works Section -->
       <section class="bg-white py-16">
         <div class="container mx-auto px-6 sm:px-8 md:px-12 lg:px-16 xl:px-20">
-          <h2 class="mb-12 text-center text-3xl font-bold tracking-tight text-gray-900">How TriviaAdvisor Works</h2>
+          <h2 class="mb-12 text-center text-3xl font-bold tracking-tight text-gray-900">How QuizAdvisor Works</h2>
           <div class="grid gap-8 md:grid-cols-3">
             <div class="flex flex-col items-center text-center">
               <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-indigo-600">
@@ -92,7 +92,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
                   <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
                 </svg>
               </div>
-              <h3 class="mb-2 text-xl font-semibold">Find Trivia Nights</h3>
+              <h3 class="mb-2 text-xl font-semibold">Find Quiz Nights</h3>
               <p class="text-gray-600">Discover pub quizzes and trivia events in your area or any city you're visiting.</p>
             </div>
             <div class="flex flex-col items-center text-center">
@@ -121,9 +121,9 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
       <section class="bg-gray-50 py-16">
         <div class="container mx-auto px-6 sm:px-8 md:px-12 lg:px-16 xl:px-20">
           <div class="mb-8 flex items-center justify-between">
-            <h2 class="text-3xl font-bold tracking-tight text-gray-900">Featured Venues</h2>
-            <a href="#" class="text-sm font-medium text-indigo-600 hover:text-indigo-700">
-              View all venues
+            <h2 class="text-3xl font-bold tracking-tight text-gray-900">Latest Venues</h2>
+            <a href={~p"/venues/latest"} class="text-sm font-medium text-indigo-600 hover:text-indigo-700">
+              View all new venues
               <span aria-hidden="true">→</span>
             </a>
           </div>

--- a/lib/trivia_advisor_web/live/venue_live/latest.ex
+++ b/lib/trivia_advisor_web/live/venue_live/latest.ex
@@ -1,0 +1,93 @@
+defmodule TriviaAdvisorWeb.VenueLive.Latest do
+  use TriviaAdvisorWeb, :live_view
+  alias TriviaAdvisorWeb.Components.UI.VenueCard
+
+  @impl true
+  def mount(_params, _session, socket) do
+    # Get more venues for this page - using the existing function but with higher limit
+    latest_venues = TriviaAdvisor.Locations.get_featured_venues(limit: 24)
+
+    # Group venues by week (based on inserted_at timestamp)
+    venues_by_week = group_venues_by_week(latest_venues)
+
+    {:ok, assign(socket,
+      page_title: "Latest Venues - QuizAdvisor",
+      latest_venues: latest_venues,
+      venues_by_week: venues_by_week
+    )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto px-4 py-8 md:px-8">
+      <div class="mb-8">
+        <div class="mb-4">
+          <nav class="flex mb-4" aria-label="Breadcrumb">
+            <ol class="inline-flex items-center space-x-1 md:space-x-3">
+              <li class="inline-flex items-center">
+                <a href="/" class="inline-flex items-center text-sm font-medium text-gray-700 hover:text-indigo-600">
+                  <svg class="w-3 h-3 mr-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="m19.707 9.293-2-2-7-7a1 1 0 0 0-1.414 0l-7 7-2 2a1 1 0 0 0 1.414 1.414L2 10.414V18a2 2 0 0 0 2 2h3a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h3a2 2 0 0 0 2-2v-7.586l.293.293a1 1 0 0 0 1.414-1.414Z"/>
+                  </svg>
+                  Home
+                </a>
+              </li>
+              <li aria-current="page">
+                <div class="flex items-center">
+                  <svg class="w-3 h-3 text-gray-400 mx-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
+                  </svg>
+                  <span class="ml-1 text-sm font-medium text-gray-500 md:ml-2">Latest Venues</span>
+                </div>
+              </li>
+            </ol>
+          </nav>
+        </div>
+        <h1 class="text-3xl font-bold text-gray-900">Latest Venues</h1>
+        <p class="mt-2 text-gray-600">Discover the newest pub quizzes and trivia venues added to QuizAdvisor</p>
+      </div>
+
+      <%= if length(@latest_venues) > 0 do %>
+        <%= for {period, venues} <- @venues_by_week do %>
+          <div class="mb-12">
+            <h2 class="mb-4 text-xl font-semibold text-gray-900 border-b pb-2">
+              <%= format_time_period(period) %>
+            </h2>
+            <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              <%= for venue <- venues do %>
+                <VenueCard.venue_card venue={venue} />
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="bg-white p-8 rounded-lg shadow-sm text-center">
+          <p class="text-gray-600">No new venues have been added recently. Check back soon!</p>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  # Group venues by week based on their inserted_at timestamp
+  defp group_venues_by_week(venues) do
+    venues
+    |> Enum.group_by(fn venue ->
+      date = venue.inserted_at || DateTime.utc_now()
+      # Get start of the week (Monday)
+      monday = Date.beginning_of_week(date)
+      # Get end of the week (Sunday)
+      sunday = Date.add(monday, 6)
+      {monday, sunday}
+    end)
+    |> Enum.sort_by(fn {{start_date, _end_date}, _venues} -> start_date end, {:desc, Date})
+  end
+
+  # Format the time period for display
+  defp format_time_period({start_date, end_date}) do
+    start_formatted = Calendar.strftime(start_date, "%b %d, %Y")
+    end_formatted = Calendar.strftime(end_date, "%b %d, %Y")
+    "#{start_formatted} - #{end_formatted}"
+  end
+end

--- a/lib/trivia_advisor_web/router.ex
+++ b/lib/trivia_advisor_web/router.ex
@@ -30,6 +30,7 @@ defmodule TriviaAdvisorWeb.Router do
     live "/cities/:slug", CityLive.Show, :show
     live "/cities", CityLive.Index, :index
     live "/countries/:slug", CountryLive.Show, :show
+    live "/venues/latest", VenueLive.Latest, :index
     live "/venues/:slug", Live.Venue.Show, :show
 
     # Admin route for image cache management (only in dev)


### PR DESCRIPTION
### TL;DR

Added a new "Latest Venues" page and venue creation date display to improve venue discovery.

### What changed?

- Created a new `/venues/latest` route and corresponding LiveView to display recently added venues
- Added venue creation date display to venue cards with a "time ago" format
- Updated homepage section title from "Featured Venues" to "Latest Venues" with a link to the new page
- Renamed "TriviaAdvisor" to "QuizAdvisor" in page titles and section headers

### How to test?

1. Visit the homepage and verify the "Latest Venues" section has a working link to the new page
2. Navigate to `/venues/latest` to see venues grouped by week
3. Check that venue cards now display the creation date with the "time ago" format
4. Verify that page titles and section headers now use "QuizAdvisor" instead of "TriviaAdvisor"

### Why make this change?

This change improves venue discovery by highlighting recently added venues, making it easier for users to find new quiz locations. The creation date on venue cards provides additional context about how long a venue has been in the system. The consistent branding update to "QuizAdvisor" ensures naming consistency throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new page displaying the latest venues, grouped by week, accessible via the "View all new venues" link.
	- Venue cards now show when each venue was added, with a human-readable creation date.

- **Improvements**
	- Updated branding and wording across the home page to "QuizAdvisor" and improved navigation labels.
	- The "Featured Venues" section is now labeled "Latest Venues" with updated link text and destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->