### PR TITLE
debugging back

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -68,8 +68,8 @@ config :trivia_advisor, dev_routes: true
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 
-# Set logger level to warn to reduce noise in logs
-config :logger, level: :warning
+# Set logger level to info to see important logs
+config :logger, level: :info
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.


### PR DESCRIPTION
### TL;DR

Changed the logger level from `:warning` to `:info` in development environment.

### What changed?

Updated the logger level configuration in `config/dev.exs` from `:warning` to `:info` to allow more detailed logging during development.

### How to test?

1. Run the application in development mode
2. Perform actions that would generate info-level logs
3. Verify that info-level messages now appear in the console output

### Why make this change?

This change enables developers to see important informational logs that were previously hidden by the more restrictive `:warning` level. Having access to info-level logs provides better visibility into application behavior during development without being overwhelmed by debug-level messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased log verbosity in the development environment to display informational messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->