### PR TITLE
fixes for geocoding

### DIFF
--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -9,7 +9,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
     popular_cities = TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true)
 
     {:ok, assign(socket,
-      page_title: "QuizAdvisor - Find the Best Pub Quizzes Near You",
+      page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",
       featured_venues: featured_venues,
       popular_cities: popular_cities
     )}
@@ -84,7 +84,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
       <!-- How It Works Section -->
       <section class="bg-white py-16">
         <div class="container mx-auto px-6 sm:px-8 md:px-12 lg:px-16 xl:px-20">
-          <h2 class="mb-12 text-center text-3xl font-bold tracking-tight text-gray-900">How QuizAdvisor Works</h2>
+          <h2 class="mb-12 text-center text-3xl font-bold tracking-tight text-gray-900">How TriviaAdvisor Works</h2>
           <div class="grid gap-8 md:grid-cols-3">
             <div class="flex flex-col items-center text-center">
               <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-indigo-600">

--- a/test/support/fixtures/locations_fixtures.ex
+++ b/test/support/fixtures/locations_fixtures.ex
@@ -104,6 +104,17 @@ defmodule TriviaAdvisor.LocationsFixtures do
       merged_attrs
       |> TriviaAdvisor.Locations.create_venue([validate: false])
 
+    # Ensure venue has fully preloaded city and country
+    venue = case venue do
+      %{city: %{country: %{__struct__: Ecto.Association.NotLoaded}}} ->
+        # If country is not loaded, reload with proper preloading
+        TriviaAdvisor.Repo.preload(venue, [city: :country])
+      %{city: %{__struct__: Ecto.Association.NotLoaded}} ->
+        # If city is not loaded, reload with proper preloading
+        TriviaAdvisor.Repo.preload(venue, [city: :country])
+      _ -> venue
+    end
+
     venue
   end
 end

--- a/test/trivia_advisor/locations_test.exs
+++ b/test/trivia_advisor/locations_test.exs
@@ -13,6 +13,10 @@ defmodule TriviaAdvisor.LocationsTest do
   alias TriviaAdvisor.Utils.Slug
   alias TriviaAdvisor.Repo
 
+  # Helper to safely convert Decimal to float
+  defp to_float(%Decimal{} = decimal), do: Decimal.to_float(decimal)
+  defp to_float(value), do: value
+
   # Define a helper function to set up expectations
   defp mock_lookup_address(fun) do
     MockGoogleLookup

--- a/test/trivia_advisor_web/live/home/index_test.exs
+++ b/test/trivia_advisor_web/live/home/index_test.exs
@@ -54,7 +54,7 @@ defmodule TriviaAdvisorWeb.HomeLive.IndexTest do
       {:ok, view, html} = live(conn, ~p"/")
 
       # Test that the page loads with the right title
-      assert html =~ "QuizAdvisor - Find the Best Pub Quizzes Near You"
+      assert html =~ "TriviaAdvisor - Find the Best Pub Quizzes Near You"
       assert html =~ "Find the Best Pub Quizzes Near You"
 
       # Test that the page has the main sections


### PR DESCRIPTION
### TL;DR

Fixed venue duplicate detection and updated branding from QuizAdvisor to TriviaAdvisor.

### What changed?

- Renamed the configuration key from `minimum_distance_meters` to `min_duplicate_distance` in the venue validation settings
- Added a helper function to safely convert latitude and longitude values to float, handling Decimal types properly
- Standardized the error atom to `:nearby_duplicates` for duplicate venue detection
- Updated all references from "QuizAdvisor" to "TriviaAdvisor" in the UI
- Enhanced the venue fixture to ensure city and country are properly preloaded

### How to test?

1. Verify that venue duplicate detection works correctly with different coordinate formats (Decimal, float)
2. Check that the home page displays "TriviaAdvisor" in the title and "How TriviaAdvisor Works" section
3. Confirm that venue fixtures properly load city and country associations

### Why make this change?

The venue duplicate detection was failing when coordinates were provided as Decimal types instead of floats. This fix ensures consistent handling of coordinate data regardless of its format. Additionally, this aligns the branding consistently as TriviaAdvisor throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of venue creation to ensure location coordinates are consistently processed.
- **Bug Fixes**
	- Ensured that venue test fixtures always include fully loaded city and country associations.
- **Style**
	- Updated branding from "QuizAdvisor" to "TriviaAdvisor" across the user interface and related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->