### PR TITLE
first fixes to recent

### DIFF
--- a/lib/trivia_advisor_web/live/dev/cache.ex
+++ b/lib/trivia_advisor_web/live/dev/cache.ex
@@ -5,117 +5,43 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, page_title: "Cache Management")}
+    {:ok, assign(socket,
+      page_title: "Cache Management",
+      cache_cleared: false,
+      latest_venues_cleared: false
+    )}
   end
 
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <h1 class="text-2xl font-bold text-gray-900 mb-6">Image Cache Management</h1>
+    <div class="container mx-auto px-4 py-8 md:px-8">
+      <h1 class="text-3xl font-bold mb-6">Cache Management</h1>
 
-      <div class="bg-white rounded-lg shadow overflow-hidden mb-8">
-        <div class="p-6">
-          <h2 class="text-lg font-medium text-gray-900 mb-4">Clear Cache</h2>
-          <p class="text-gray-600 mb-4">Clear the Unsplash image cache to force fetching fresh images from the API.</p>
+      <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+        <h2 class="text-xl font-semibold mb-4">Latest Venues Cache</h2>
+        <p class="mb-4">Clear only the Latest Venues cache to force a fresh lookup of the most recently added venues.</p>
 
-          <div class="space-y-4">
-            <div>
-              <button
-                phx-click="clear-all-cache"
-                class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-              >
-                Clear All Cache
-              </button>
-              <p class="mt-1 text-sm text-gray-500">Removes all cached images</p>
-            </div>
+        <button phx-click="clear-latest-venues-cache" class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded">
+          Clear Latest Venues Cache
+        </button>
 
-            <div class="mt-6">
-              <h3 class="text-md font-medium text-gray-900 mb-2">Clear City Image</h3>
-              <div class="flex gap-4">
-                <div>
-                  <form phx-submit="clear-city-cache" class="flex gap-2">
-                    <input
-                      type="text"
-                      name="city_name"
-                      placeholder="City name"
-                      required
-                      class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
-                    />
-                    <button
-                      type="submit"
-                      class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                    >
-                      Clear
-                    </button>
-                  </form>
-                </div>
-              </div>
-            </div>
-
-            <div class="mt-6">
-              <h3 class="text-md font-medium text-gray-900 mb-2">Clear Venue Image</h3>
-              <div class="flex gap-4">
-                <div>
-                  <form phx-submit="clear-venue-cache" class="flex gap-2">
-                    <input
-                      type="text"
-                      name="venue_name"
-                      placeholder="Venue name"
-                      required
-                      class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
-                    />
-                    <button
-                      type="submit"
-                      class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                    >
-                      Clear
-                    </button>
-                  </form>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <%= if @latest_venues_cleared do %>
+          <p class="mt-4 text-green-600 font-semibold">Latest Venues cache cleared successfully!</p>
+        <% end %>
       </div>
 
-      <div class="mt-8 bg-white rounded-lg shadow overflow-hidden">
-        <div class="p-6">
-          <h2 class="text-lg font-medium text-gray-900 mb-4">Popular Pages</h2>
-          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <a
-              href="/"
-              class="block p-4 border rounded-lg hover:bg-gray-50"
-            >
-              <h3 class="font-medium text-gray-900">Home</h3>
-              <p class="mt-1 text-sm text-gray-500">Return to the home page</p>
-            </a>
+      <div class="bg-white rounded-lg shadow-sm p-6">
+        <h2 class="text-xl font-semibold mb-4">Global Cache</h2>
+        <p class="mb-4">Warning: This will clear all cached data in the application. Use with caution!</p>
 
-            <a
-              href="/cities/london"
-              class="block p-4 border rounded-lg hover:bg-gray-50"
-            >
-              <h3 class="font-medium text-gray-900">London</h3>
-              <p class="mt-1 text-sm text-gray-500">View London city page</p>
-            </a>
+        <button phx-click="clear-all-cache" class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded">
+          Clear All Cached Data
+        </button>
 
-            <a
-              href="/cities/new-york"
-              class="block p-4 border rounded-lg hover:bg-gray-50"
-            >
-              <h3 class="font-medium text-gray-900">New York</h3>
-              <p class="mt-1 text-sm text-gray-500">View New York city page</p>
-            </a>
-
-            <a
-              href="/venues/1"
-              class="block p-4 border rounded-lg hover:bg-gray-50"
-            >
-              <h3 class="font-medium text-gray-900">Pub Quiz Champion</h3>
-              <p class="mt-1 text-sm text-gray-500">View venue page</p>
-            </a>
-          </div>
-        </div>
+        <%= if @cache_cleared do %>
+          <p class="mt-4 text-green-600 font-semibold">Cache cleared successfully!</p>
+        <% end %>
       </div>
     </div>
     """
@@ -123,8 +49,33 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
 
   @impl true
   def handle_event("clear-all-cache", _params, socket) do
-    UnsplashService.clear_cache()
-    {:noreply, put_flash(socket, :info, "All image cache cleared successfully")}
+    TriviaAdvisor.Cache.clear()
+    {:noreply, assign(socket, cache_cleared: true)}
+  end
+
+  @impl true
+  def handle_event("clear-latest-venues-cache", _params, socket) do
+    # Clear only the latest venues cache entries
+    clear_latest_venues_cache()
+    {:noreply, assign(socket, latest_venues_cleared: true)}
+  end
+
+  defp clear_latest_venues_cache do
+    # This function selectively clears only the cache entries for latest venues
+    # The key format is "latest_venues:limit:X" where X is the limit
+    # We'll try to clear entries with common limits
+    [4, 24]
+    |> Enum.each(fn limit ->
+      key = "latest_venues:limit:#{limit}"
+      case :ets.lookup(:trivia_advisor_cache, key) do
+        [] ->
+          # Key not found, do nothing
+          nil
+        _entry ->
+          # Key found, delete it
+          :ets.delete(:trivia_advisor_cache, key)
+      end
+    end)
   end
 
   @impl true

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -4,13 +4,13 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    # Use real data with caching
-    featured_venues = TriviaAdvisor.Locations.get_featured_venues(limit: 4)
+    # Use real data with caching - replace featured_venues with latest_venues
+    latest_venues = TriviaAdvisor.Locations.get_latest_venues(limit: 4, force_refresh: true)
     popular_cities = TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true)
 
     {:ok, assign(socket,
       page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",
-      featured_venues: featured_venues,
+      featured_venues: latest_venues,
       popular_cities: popular_cities
     )}
   end

--- a/lib/trivia_advisor_web/live/venue_live/latest.ex
+++ b/lib/trivia_advisor_web/live/venue_live/latest.ex
@@ -4,8 +4,8 @@ defmodule TriviaAdvisorWeb.VenueLive.Latest do
 
   @impl true
   def mount(_params, _session, socket) do
-    # Get more venues for this page - using the existing function but with higher limit
-    latest_venues = TriviaAdvisor.Locations.get_featured_venues(limit: 24)
+    # Get more venues for this page using the new get_latest_venues function with force_refresh
+    latest_venues = TriviaAdvisor.Locations.get_latest_venues(limit: 24, force_refresh: true)
 
     # Group venues by week (based on inserted_at timestamp)
     venues_by_week = group_venues_by_week(latest_venues)


### PR DESCRIPTION
### TL;DR

Added a new `get_latest_venues/1` function to display the most recently created venues instead of featured venues.

### What changed?

- Created a new `get_latest_venues/1` function in the Locations module that explicitly sorts venues by insertion date
- Updated the home page to use `get_latest_venues/1` instead of `get_featured_venues/1`
- Updated the venues latest page to use the new function with a higher limit
- Improved the cache management page with specific controls for clearing the latest venues cache
- Added helper functions to fetch and cache latest venues with a 1-hour TTL

### How to test?

1. Visit the home page to see the most recently added venues
2. Visit the latest venues page to see a larger collection of venues sorted by creation date
3. Use the updated cache management page at `/dev/cache` to clear the latest venues cache and verify it refreshes

### Why make this change?

This change improves the user experience by showing the newest venues on the home page and latest venues page, making it easier for users to discover recently added venues. The explicit sorting by insertion date ensures that the newest venues are always displayed first, unlike the previous implementation which didn't have a specific ordering. The shorter cache TTL (1 hour) ensures that newly added venues will appear more quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated feature to display the latest venues, sorted by their creation date, on relevant pages.
  - Introduced a new option in the admin cache management interface to clear only the latest venues cache.

- **Improvements**
  - Updated the home page and latest venues page to show the most recently added venues instead of previously featured ones.
  - Simplified and reorganized the cache management UI for easier navigation and clearer feedback when clearing caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->