### PR TITLE
small changes

### DIFF
--- a/lib/trivia_advisor_web/live/dev/cache.ex
+++ b/lib/trivia_advisor_web/live/dev/cache.ex
@@ -64,7 +64,7 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
     # This function selectively clears only the cache entries for latest venues
     # The key format is "latest_venues:limit:X" where X is the limit
     # We'll try to clear entries with common limits
-    [4, 24]
+    [4, 24, 72]
     |> Enum.each(fn limit ->
       key = "latest_venues:limit:#{limit}"
       case :ets.lookup(:trivia_advisor_cache, key) do
@@ -74,6 +74,17 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
         _entry ->
           # Key found, delete it
           :ets.delete(:trivia_advisor_cache, key)
+      end
+
+      # Also clear diverse latest venues cache
+      diverse_key = "diverse_latest_venues:limit:#{limit}"
+      case :ets.lookup(:trivia_advisor_cache, diverse_key) do
+        [] ->
+          # Key not found, do nothing
+          nil
+        _entry ->
+          # Key found, delete it
+          :ets.delete(:trivia_advisor_cache, diverse_key)
       end
     end)
   end

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -4,8 +4,8 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    # Use real data with caching - replace featured_venues with latest_venues
-    latest_venues = TriviaAdvisor.Locations.get_latest_venues(limit: 4, force_refresh: true)
+    # Use diverse latest venues function to show venues from different countries
+    latest_venues = TriviaAdvisor.Locations.get_diverse_latest_venues(limit: 4, force_refresh: true)
     popular_cities = TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true)
 
     {:ok, assign(socket,

--- a/lib/trivia_advisor_web/live/venue_live/latest.ex
+++ b/lib/trivia_advisor_web/live/venue_live/latest.ex
@@ -5,7 +5,8 @@ defmodule TriviaAdvisorWeb.VenueLive.Latest do
   @impl true
   def mount(_params, _session, socket) do
     # Get more venues for this page using the new get_latest_venues function with force_refresh
-    latest_venues = TriviaAdvisor.Locations.get_latest_venues(limit: 24, force_refresh: true)
+    # Increased limit from 24 to 72 to show more historical data
+    latest_venues = TriviaAdvisor.Locations.get_latest_venues(limit: 72, force_refresh: true)
 
     # Group venues by week (based on inserted_at timestamp)
     venues_by_week = group_venues_by_week(latest_venues)


### PR DESCRIPTION
### TL;DR

Added country diversity to featured venues on the homepage to showcase venues from different countries.

### What changed?

- Created a new `get_diverse_latest_venues/1` function that ensures venues from multiple countries are included in results
- Implemented caching for the diverse venues query with a 1-hour TTL
- Updated the homepage to use the new diverse venues function instead of regular latest venues
- Increased the venue limit on the Latest Venues page from 24 to 72 to show more historical data
- Added cache clearing for the new diverse venues cache in the dev tools

### How to test?

1. Visit the homepage and verify that the featured venues section shows venues from different countries
2. Check the Latest Venues page to confirm it displays more historical venue data (up to 72 venues)
3. Use the dev cache tools to clear the venue caches and verify they rebuild correctly

### Why make this change?

The homepage previously showed only the most recent venues, which often came from the same country or region. This change ensures geographic diversity in the featured venues section, providing better representation of global trivia locations and improving discovery for users from different regions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Home page now displays the latest venues with increased country diversity, showcasing venues from different countries.
- **Improvements**
  - Venue listing page now shows more historical venues, increasing the display limit from 24 to 72.
  - Enhanced cache clearing to include new diverse venue listings and expanded limits for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->