### PR TITLE
warnings

### DIFF
--- a/lib/trivia_advisor_web/live/dev/cache.ex
+++ b/lib/trivia_advisor_web/live/dev/cache.ex
@@ -60,6 +60,24 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
     {:noreply, assign(socket, latest_venues_cleared: true)}
   end
 
+  @impl true
+  def handle_event("clear-city-cache", %{"city_name" => city_name}, socket) when city_name != "" do
+    UnsplashService.clear_cache("city", city_name)
+    {:noreply, put_flash(socket, :info, "Cache for city '#{city_name}' cleared successfully")}
+  end
+
+  @impl true
+  def handle_event("clear-venue-cache", %{"venue_name" => venue_name}, socket) when venue_name != "" do
+    UnsplashService.clear_cache("venue", venue_name)
+    {:noreply, put_flash(socket, :info, "Cache for venue '#{venue_name}' cleared successfully")}
+  end
+
+  @impl true
+  def handle_event(event, params, socket) do
+    Logger.warning("Unhandled event: #{event}, params: #{inspect(params)}")
+    {:noreply, socket}
+  end
+
   defp clear_latest_venues_cache do
     # This function selectively clears only the cache entries for latest venues
     # The key format is "latest_venues:limit:X" where X is the limit
@@ -87,23 +105,5 @@ defmodule TriviaAdvisorWeb.DevLive.Cache do
           :ets.delete(:trivia_advisor_cache, diverse_key)
       end
     end)
-  end
-
-  @impl true
-  def handle_event("clear-city-cache", %{"city_name" => city_name}, socket) when city_name != "" do
-    UnsplashService.clear_cache("city", city_name)
-    {:noreply, put_flash(socket, :info, "Cache for city '#{city_name}' cleared successfully")}
-  end
-
-  @impl true
-  def handle_event("clear-venue-cache", %{"venue_name" => venue_name}, socket) when venue_name != "" do
-    UnsplashService.clear_cache("venue", venue_name)
-    {:noreply, put_flash(socket, :info, "Cache for venue '#{venue_name}' cleared successfully")}
-  end
-
-  @impl true
-  def handle_event(event, params, socket) do
-    Logger.warning("Unhandled event: #{event}, params: #{inspect(params)}")
-    {:noreply, socket}
   end
 end


### PR DESCRIPTION
### TL;DR

Reordered event handler functions in the cache module to improve code organization.

### What changed?

Moved the event handler functions (`clear-city-cache`, `clear-venue-cache`, and the catch-all handler) above the private helper functions in the `TriviaAdvisorWeb.DevLive.Cache` module. The functionality remains identical, but the code structure now follows a more conventional pattern with public functions appearing before private ones.

### How to test?

1. Navigate to the dev cache management page
2. Try clearing city cache with a specific city name
3. Try clearing venue cache with a specific venue name
4. Verify that both operations work as expected with appropriate flash messages

### Why make this change?

This change improves code readability by following the Elixir convention of grouping public interface functions (like event handlers) at the top of the module, followed by private helper functions. This makes the code easier to navigate and maintain while preserving all existing functionality.