### PR TITLE
small UTM

### DIFF
--- a/lib/trivia_advisor/services/unsplash_image_fetcher.ex
+++ b/lib/trivia_advisor/services/unsplash_image_fetcher.ex
@@ -112,7 +112,7 @@ defmodule TriviaAdvisor.Services.UnsplashImageFetcher do
           "photographer_name" => "Fallback Image",
           "photographer_username" => "trivia_advisor",
           "photographer_url" => nil,
-          "unsplash_url" => "https://unsplash.com"
+          "unsplash_url" => "https://unsplash.com?utm_source=trivia_advisor&utm_medium=referral"
         },
         "fetched_at" => DateTime.utc_now() |> DateTime.to_iso8601()
       }
@@ -152,7 +152,7 @@ defmodule TriviaAdvisor.Services.UnsplashImageFetcher do
                     "attribution" => %{
                       "photographer_name" => get_in(result, ["user", "name"]),
                       "photographer_username" => get_in(result, ["user", "username"]),
-                      "photographer_url" => get_in(result, ["user", "links", "html"]),
+                      "photographer_url" => "#{get_in(result, ["user", "links", "html"])}?utm_source=trivia_advisor&utm_medium=referral",
                       "unsplash_url" => "#{get_in(result, ["links", "html"])}?utm_source=trivia_advisor&utm_medium=referral"
                     },
                     "fetched_at" => DateTime.utc_now() |> DateTime.to_iso8601()

--- a/lib/trivia_advisor_web/helpers/image_helpers.ex
+++ b/lib/trivia_advisor_web/helpers/image_helpers.ex
@@ -108,9 +108,11 @@ defmodule TriviaAdvisorWeb.Helpers.ImageHelpers do
 
         # Extract attribution
         attribution = if Map.has_key?(current_image, "attribution") do
-          current_image["attribution"]
+          # Ensure UTM parameters for photographer URL
+          attribution = current_image["attribution"]
+          ensure_utm_parameters(attribution)
         else
-          %{"photographer_name" => "Photographer", "photographer_url" => nil, "unsplash_url" => "https://unsplash.com"}
+          %{"photographer_name" => "Photographer", "unsplash_url" => "https://unsplash.com?utm_source=trivia_advisor&utm_medium=referral"}
         end
 
         {image_url, attribution}
@@ -121,8 +123,34 @@ defmodule TriviaAdvisorWeb.Helpers.ImageHelpers do
     else
       # If no gallery or no images, use fallback hardcoded image URL
       image_url = get_fallback_city_image(city.name)
-      {image_url, %{"photographer_name" => "Unsplash", "unsplash_url" => "https://unsplash.com"}}
+      {image_url, %{"photographer_name" => "Unsplash", "unsplash_url" => "https://unsplash.com?utm_source=trivia_advisor&utm_medium=referral"}}
     end
+  end
+
+  # Ensure UTM parameters are present for attribution URLs
+  defp ensure_utm_parameters(attribution) do
+    utm_params = "?utm_source=trivia_advisor&utm_medium=referral"
+
+    # Handle both string and atom keys
+    photographer_url = Map.get(attribution, "photographer_url") || Map.get(attribution, :photographer_url)
+    unsplash_url = Map.get(attribution, "unsplash_url") || Map.get(attribution, :unsplash_url)
+
+    # Only update URLs if they exist and don't already have UTM params
+    updated_attribution = attribution
+
+    updated_attribution = if photographer_url && not String.contains?(photographer_url, "utm_source") do
+      Map.put(updated_attribution, "photographer_url", "#{photographer_url}#{utm_params}")
+    else
+      updated_attribution
+    end
+
+    updated_attribution = if unsplash_url && not String.contains?(unsplash_url, "utm_source") do
+      Map.put(updated_attribution, "unsplash_url", "#{unsplash_url}#{utm_params}")
+    else
+      updated_attribution
+    end
+
+    updated_attribution
   end
 
   @doc """

--- a/lib/trivia_advisor_web/live/city/components/header.ex
+++ b/lib/trivia_advisor_web/live/city/components/header.ex
@@ -36,15 +36,15 @@ defmodule TriviaAdvisorWeb.CityLive.Components.Header do
           <%= if @city.attribution do %>
             <p class="mt-1 text-xs opacity-80">
               Photo by
-              <%= if Map.get(@city.attribution, "photographer_url") do %>
-                <a href={Map.get(@city.attribution, :photographer_url) || Map.get(@city.attribution, "photographer_url")} target="_blank" rel="noopener" class="hover:underline">
-                  <%= Map.get(@city.attribution, :photographer_name) || Map.get(@city.attribution, "photographer_name") %>
+              <%= if get_photographer_url(@city.attribution) do %>
+                <a href={get_photographer_url(@city.attribution)} target="_blank" rel="noopener" class="hover:underline">
+                  <%= get_photographer_name(@city.attribution) %>
                 </a>
               <% else %>
-                <%= Map.get(@city.attribution, :photographer_name) || Map.get(@city.attribution, "photographer_name") %>
+                <%= get_photographer_name(@city.attribution) %>
               <% end %>
-              <%= if Map.get(@city.attribution, :unsplash_url) || Map.get(@city.attribution, "unsplash_url") do %>
-                on <a href={Map.get(@city.attribution, :unsplash_url) || Map.get(@city.attribution, "unsplash_url")} target="_blank" rel="noopener" class="hover:underline">Unsplash</a>
+              <%= if get_unsplash_url(@city.attribution) do %>
+                on <a href={get_unsplash_url(@city.attribution)} target="_blank" rel="noopener" class="hover:underline">Unsplash</a>
               <% end %>
             </p>
           <% end %>
@@ -52,5 +52,18 @@ defmodule TriviaAdvisorWeb.CityLive.Components.Header do
       </div>
     </div>
     """
+  end
+
+  # Helper functions to get attribution data in a consistent format
+  defp get_photographer_name(attribution) do
+    Map.get(attribution, :photographer_name) || Map.get(attribution, "photographer_name")
+  end
+
+  defp get_photographer_url(attribution) do
+    Map.get(attribution, :photographer_url) || Map.get(attribution, "photographer_url")
+  end
+
+  defp get_unsplash_url(attribution) do
+    Map.get(attribution, :unsplash_url) || Map.get(attribution, "unsplash_url")
   end
 end


### PR DESCRIPTION
### TL;DR

Added proper UTM parameters to Unsplash attribution links to comply with their API requirements.

### What changed?

- Added UTM parameters (`utm_source=trivia_advisor&utm_medium=referral`) to all Unsplash and photographer URLs
- Created a new `ensure_utm_parameters` helper function to consistently apply UTM parameters to attribution links
- Added helper functions in the Header component to consistently retrieve attribution data regardless of string/atom keys
- Fixed the fallback image attribution to include proper UTM parameters

### How to test?

1. View any city page that displays Unsplash images
2. Check that the photo attribution links (both photographer and Unsplash links) contain the UTM parameters
3. Verify that clicking these links properly redirects to the expected URLs with the UTM parameters intact

### Why make this change?

This change ensures compliance with Unsplash's API guidelines, which require proper attribution with UTM parameters for tracking purposes. This is a requirement for using their service and ensures we're properly crediting photographers while allowing Unsplash to track referrals from our application.