### PR TITLE
change worker

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -33,7 +33,8 @@ config :trivia_advisor, Oban,
        {"0 6 * * *", TriviaAdvisor.Scraping.Oban.PubquizIndexJob}, # Run at 6 AM daily
        {"0 2 * * *", TriviaAdvisor.Locations.Oban.DailyRecalibrateWorker}, # Run at 2 AM daily
        {"0 1 * * *", TriviaAdvisor.Workers.UnsplashImageRefresher, args: %{"action" => "refresh"}}, # Run at 1 AM daily
-       {"0 7 * * *", TriviaAdvisor.Workers.SitemapWorker} # Run at 7 AM daily
+       {"0 7 * * *", TriviaAdvisor.Workers.SitemapWorker}, # Run at 7 AM daily
+       {"0 3 * * *", TriviaAdvisor.Workers.VenueStatisticsWorker} # Run at 3 AM daily
      ]},
     {Oban.Plugins.Pruner, max_age: 604800}  # 7 days in seconds
   ]

--- a/lib/trivia_advisor/workers/venue_statistics_worker.ex
+++ b/lib/trivia_advisor/workers/venue_statistics_worker.ex
@@ -1,0 +1,65 @@
+defmodule TriviaAdvisor.Workers.VenueStatisticsWorker do
+  @moduledoc """
+  Oban worker that refreshes venue statistics daily.
+
+  This worker runs via Oban's cron plugin to ensure venue statistics
+  are regularly updated and cached, improving performance across the app
+  by preventing on-demand recalculations during page loads.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 3
+
+  import Ecto.Query, warn: false
+  require Logger
+  alias TriviaAdvisor.VenueStatistics
+
+  @impl Oban.Worker
+  def perform(%{id: job_id} = _job) do
+    start_time = System.monotonic_time(:millisecond)
+    Logger.info("Starting venue statistics refresh...")
+
+    # Refresh venue statistics with force_refresh option
+    venues_count = VenueStatistics.count_active_venues(force_refresh: true)
+    venues_by_country = VenueStatistics.venues_by_country(force_refresh: true)
+    countries_count = Enum.count(venues_by_country)
+
+    duration_ms = System.monotonic_time(:millisecond) - start_time
+
+    Logger.info("""
+    Venue statistics refresh completed.
+    Duration: #{duration_ms}ms
+    Total active venues: #{venues_count}
+    Total countries with venues: #{countries_count}
+    """)
+
+    # Create metadata for the job
+    metadata = %{
+      venues_count: venues_count,
+      countries_count: countries_count,
+      duration_ms: duration_ms
+    }
+
+    # Update the job's meta column
+    TriviaAdvisor.Repo.update_all(
+      from(j in "oban_jobs", where: j.id == ^job_id),
+      set: [meta: metadata]
+    )
+
+    :ok
+  end
+
+  @doc """
+  Enqueues a job to refresh venue statistics.
+
+  ## Examples
+
+      iex> VenueStatisticsWorker.perform_async()
+      {:ok, %Oban.Job{}}
+
+  """
+  def perform_async do
+    %{}
+    |> new()
+    |> Oban.insert()
+  end
+end

--- a/lib/trivia_advisor_web/live/home/index.ex
+++ b/lib/trivia_advisor_web/live/home/index.ex
@@ -9,8 +9,7 @@ defmodule TriviaAdvisorWeb.HomeLive.Index do
     latest_venues = TriviaAdvisor.Locations.get_diverse_latest_venues(limit: 4, force_refresh: true)
     popular_cities = TriviaAdvisor.Locations.get_popular_cities(limit: 6, diverse_countries: true)
 
-    # Trigger venue statistics calculation
-    TriviaAdvisor.VenueStatistics.schedule_refresh()
+    # We're no longer refreshing venue statistics here since it's handled by the worker
 
     {:ok, assign(socket,
       page_title: "TriviaAdvisor - Find the Best Pub Quizzes Near You",


### PR DESCRIPTION
### TL;DR

Added a daily venue statistics worker to refresh venue statistics via a scheduled job instead of on-demand.

### What changed?

- Created a new `VenueStatisticsWorker` module that refreshes venue statistics and caches the results
- Scheduled the worker to run daily at 3 AM via Oban's cron plugin
- Removed the on-demand statistics refresh from the home page live view

### How to test?

1. Verify the worker runs correctly by manually triggering it:
   ```elixir
   TriviaAdvisor.Workers.VenueStatisticsWorker.perform_async()
   ```
2. Check the logs to confirm statistics are being refreshed
3. Verify the home page still displays correct venue statistics without the on-demand refresh

### Why make this change?

This change improves application performance by moving venue statistics calculations to a scheduled background job instead of calculating them during page loads. The statistics are now pre-calculated and cached daily, reducing database load during peak usage and providing faster page rendering for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Venue statistics are now refreshed daily at 3 AM automatically.

- **Improvements**
  - The process for refreshing venue statistics is now managed by a scheduled background job, improving reliability and efficiency.

- **Other**
  - Updated documentation to reflect the new background refresh process for venue statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->