### PR TITLE
fix warnings

### DIFF
--- a/lib/trivia_advisor/workers/unsplash_image_refresher.ex
+++ b/lib/trivia_advisor/workers/unsplash_image_refresher.ex
@@ -25,13 +25,7 @@ defmodule TriviaAdvisor.Workers.UnsplashImageRefresher do
   @weekly_refresh 14 * 24 * 60 * 60  # 14 days instead of 7 days
   @monthly_refresh 60 * 24 * 60 * 60  # 60 days instead of 30 days
 
-  # Rate limit configuration
-  @production_rate_limit 5000  # Requests per hour in production
-  @req_buffer_percent 0.8      # Use 80% of allowed requests to be safe
-  @requests_per_location 1     # Each location typically uses 1 API request
-
   # Batch sizing
-  @max_countries_per_batch 27  # Process all countries in one batch (we have 27 total)
   @max_cities_per_batch 200    # Process cities in larger batches (we have ~1455 total)
 
   @impl Oban.Worker


### PR DESCRIPTION
### TL;DR

Removed unused rate limit configuration and country batch size constants from the UnsplashImageRefresher worker.

### What changed?

- Removed three unused rate limit configuration constants:
  - `@production_rate_limit` (5000 requests per hour)
  - `@req_buffer_percent` (0.8 or 80%)
  - `@requests_per_location` (1 request per location)
- Removed the `@max_countries_per_batch` constant (27 countries)
- Kept the `@max_cities_per_batch` constant (200 cities)

### How to test?

Verify that the UnsplashImageRefresher worker still functions correctly by:
1. Running the worker manually or waiting for its scheduled execution
2. Confirming that image refreshing for both countries and cities works as expected
3. Checking logs to ensure no errors related to missing constants

### Why make this change?

These constants were no longer being used in the codebase, making them unnecessary. Removing them improves code clarity by eliminating unused variables. The worker likely evolved to handle rate limiting differently or these parameters were moved elsewhere in the application.