### PR TITLE
fixes

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -32,6 +32,7 @@ config :trivia_advisor, Oban,
        {"0 5 * * *", TriviaAdvisor.Scraping.Oban.GeeksWhoDrinkIndexJob},
        {"0 6 * * *", TriviaAdvisor.Scraping.Oban.PubquizIndexJob}, # Run at 6 AM daily
        {"0 2 * * *", TriviaAdvisor.Locations.Oban.DailyRecalibrateWorker}, # Run at 2 AM daily
+       {"0 3 * * *", TriviaAdvisor.Workers.PopularCitiesRefreshWorker}, # Run at 3 AM daily
        {"0 1 * * *", TriviaAdvisor.Workers.UnsplashImageRefresher, args: %{"action" => "refresh"}}, # Run at 1 AM daily
        {"0 7 * * *", TriviaAdvisor.Workers.SitemapWorker}, # Run at 7 AM daily
        {"0 3 * * *", TriviaAdvisor.Workers.VenueStatisticsWorker} # Run at 3 AM daily

--- a/config/test.exs
+++ b/config/test.exs
@@ -62,6 +62,6 @@ config :trivia_advisor, :http_client, HTTPoison.Mock
 config :trivia_advisor, env: :test
 
 config :trivia_advisor, Oban,
-  testing: :inline,
+  testing: :manual,
   queues: false,
   plugins: false

--- a/lib/trivia_advisor/locations/oban/daily_recalibrate_worker.ex
+++ b/lib/trivia_advisor/locations/oban/daily_recalibrate_worker.ex
@@ -86,6 +86,7 @@ defmodule TriviaAdvisor.Locations.Oban.DailyRecalibrateWorker do
       |> Enum.each(fn limit ->
         [50, 30]
         |> Enum.each(fn distance ->
+          # Cache each combination directly without scheduling a job
           cache_city_combination(limit: limit, distance_threshold: distance, diverse_countries: diverse)
         end)
       end)
@@ -183,7 +184,7 @@ defmodule TriviaAdvisor.Locations.Oban.DailyRecalibrateWorker do
   defp calculate_avg_coordinates(city_id) do
     # Query to get average latitude and longitude
     query = from v in Venue,
-            where: v.city_id == ^city_id and not is_nil(v.latitude) and not is_nil(v.longitude),
+            where: v.city_id == ^city_id and is_nil(v.latitude) == false and is_nil(v.longitude) == false,
             select: {
               fragment("AVG(CAST(? AS FLOAT))", v.latitude),
               fragment("AVG(CAST(? AS FLOAT))", v.longitude)

--- a/lib/trivia_advisor/workers/popular_cities_refresh_worker.ex
+++ b/lib/trivia_advisor/workers/popular_cities_refresh_worker.ex
@@ -1,0 +1,96 @@
+defmodule TriviaAdvisor.Workers.PopularCitiesRefreshWorker do
+  @moduledoc """
+  Oban worker that refreshes the popular cities cache.
+
+  This worker is dedicated to refreshing the popular cities cache
+  without recursion issues with the DailyRecalibrateWorker.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 3
+  require Logger
+  import Ecto.Query
+
+  @impl Oban.Worker
+  def perform(%{id: job_id}) do
+    start_time = System.monotonic_time(:millisecond)
+    Logger.info("Starting popular cities cache refresh...")
+
+    cache_popular_cities()
+
+    duration_ms = System.monotonic_time(:millisecond) - start_time
+    Logger.info("Popular cities cache refresh completed in #{duration_ms}ms")
+
+    # Update job metadata
+    TriviaAdvisor.Repo.update_all(
+      from(j in "oban_jobs", where: j.id == ^job_id),
+      set: [meta: %{duration_ms: duration_ms}]
+    )
+
+    :ok
+  end
+
+  # Cache popular cities for each common parameter combination
+  defp cache_popular_cities do
+    Logger.info("Caching popular cities combinations")
+
+    # Cache various combinations of parameters
+    [true, false]
+    |> Enum.each(fn diverse ->
+      [15, 10, 6]
+      |> Enum.each(fn limit ->
+        [50, 30]
+        |> Enum.each(fn distance ->
+          cache_city_combination(limit: limit, distance_threshold: distance, diverse_countries: diverse)
+        end)
+      end)
+    end)
+
+    # Always cache the default combination as fallback
+    store_fallback_popular_cities()
+
+    Logger.info("Completed caching popular cities")
+  end
+
+  # Cache a specific combination of parameters
+  defp cache_city_combination(opts) do
+    cache_key = "popular_cities:#{inspect(opts)}"
+
+    try do
+      # Calculate popular cities
+      cities = TriviaAdvisor.Locations.do_get_popular_cities(opts)
+
+      # Store in cache with 24hr TTL
+      TriviaAdvisor.Cache.store(cache_key, cities, 86400)
+
+      Logger.info("Cached popular cities for #{inspect(opts)}")
+    rescue
+      e ->
+        # Log error and continue with other combinations
+        Logger.error("Failed to cache popular cities for #{inspect(opts)}: #{inspect(e)}")
+    end
+  end
+
+  # Store fallback popular cities in cache
+  defp store_fallback_popular_cities do
+    # Cache all common combinations with these fallback cities
+    [true, false]
+    |> Enum.each(fn diverse ->
+      [15, 10, 6]
+      |> Enum.each(fn limit ->
+        [50, 30]
+        |> Enum.each(fn distance ->
+          opts = [limit: limit, distance_threshold: distance, diverse_countries: diverse]
+          cache_key = "popular_cities:#{inspect(opts)}"
+
+          # Get fallback cities from central function
+          cities = TriviaAdvisor.Locations.get_fallback_popular_cities(limit: limit)
+
+          # Store in cache with 24hr TTL
+          TriviaAdvisor.Cache.store(cache_key, cities, 86400)
+        end)
+      end)
+    end)
+
+    Logger.info("Stored fallback popular cities in cache")
+  end
+end


### PR DESCRIPTION
### TL;DR

Added a dedicated worker for refreshing popular cities cache to prevent recursion issues.

### What changed?

- Created a new `PopularCitiesRefreshWorker` module to handle popular cities cache refresh independently
- Added a scheduled job for the new worker to run at 3 AM daily in production
- Updated Oban testing mode from `:inline` to `:manual` in test environment
- Improved error handling in the popular cities refresh process with better exception handling
- Enhanced image URL extraction logic with more robust nil checks
- Fixed SQL query in `DailyRecalibrateWorker` to use `is_nil(field) == false` instead of `not is_nil(field)`

### How to test?

1. Verify the new worker runs correctly by manually triggering it:
   ```elixir
   %{} |> TriviaAdvisor.Workers.PopularCitiesRefreshWorker.new() |> Oban.insert()
   ```
2. Check that popular cities are properly cached with various parameter combinations
3. Confirm the improved error handling by testing with malformed data
4. Verify the image URL extraction works correctly with different Unsplash gallery structures

### Why make this change?

The previous implementation had potential recursion issues when refreshing popular cities cache. By creating a dedicated worker, we avoid circular dependencies and improve the reliability of the cache refresh process. The enhanced error handling and nil checks also make the system more robust against unexpected data formats and edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new background job that refreshes the popular cities cache daily at 3 AM.

- **Bug Fixes**
  - Improved error handling and robustness when extracting image URLs and scheduling background jobs, reducing the risk of runtime errors.

- **Documentation**
  - Added clarifying comments to improve code readability.

- **Chores**
  - Updated test environment settings to require manual triggering of background jobs during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->