### PR TITLE
image rotation

### DIFF
--- a/lib/trivia_advisor/locations.ex
+++ b/lib/trivia_advisor/locations.ex
@@ -1457,6 +1457,4 @@ defmodule TriviaAdvisor.Locations do
         fallback
     end
   end
-
-  # The unused function select_diverse_venues/2 has been removed
 end

--- a/lib/trivia_advisor_web/helpers/image_helpers.ex
+++ b/lib/trivia_advisor_web/helpers/image_helpers.ex
@@ -84,6 +84,7 @@ defmodule TriviaAdvisorWeb.Helpers.ImageHelpers do
   @doc """
   Gets a city image URL from Unsplash or fallbacks.
   Returns a tuple with {image_url, attribution_map}.
+  Rotates images based on the current hour without updating the database.
   """
   def get_city_image_with_attribution(city) do
     # Default image URL if none is found
@@ -95,11 +96,17 @@ defmodule TriviaAdvisorWeb.Helpers.ImageHelpers do
        is_list(city.unsplash_gallery["images"]) &&
        length(city.unsplash_gallery["images"]) > 0 do
 
-      # Get the current index or default to 0
-      current_index = Map.get(city.unsplash_gallery, "current_index", 0)
+      # Get all available images
+      images = city.unsplash_gallery["images"]
+      total_images = length(images)
+
+      # Calculate which image to show based on current hour
+      # This will rotate images hourly without needing to update the database
+      current_hour = DateTime.utc_now().hour
+      image_index = rem(current_hour, total_images)
 
       # Get the current image safely
-      current_image = Enum.at(city.unsplash_gallery["images"], current_index) ||
+      current_image = Enum.at(city.unsplash_gallery["images"], image_index) ||
                       List.first(city.unsplash_gallery["images"])
 
       if current_image && Map.has_key?(current_image, "url") do


### PR DESCRIPTION
# Implement Time-Based Image Rotation for City and Country Galleries

### TL;DR

Replaced manual image rotation with a deterministic time-based rotation system that changes images hourly without requiring database updates.

### What changed?

- Added a new `get_hourly_image_index/2` function that calculates image indices based on current hour, day of year, and entity ID
- Refactored `get_city_images_batch/1` to use the new time-based rotation
- Updated `get_image_from_db/2` to use a single, consistent approach for both cities and countries
- Removed the need to store and update `current_index` in the database
- Consolidated image retrieval logic to reduce code duplication
- Improved `ImageHelpers.get_city_image_with_attribution/1` to use time-based rotation
- Removed an obsolete comment in the Locations module

### How to test?

1. View city and country pages at different hours to verify images rotate
2. Check that different cities/countries show different images at the same time
3. Verify that image rotation works without database updates by checking logs
4. Test batch image loading for multiple cities to ensure correct rotation

### Why make this change?

The previous approach required database updates to rotate images, which created unnecessary database load and potential race conditions. The new time-based approach:

- Eliminates database writes for image rotation
- Provides consistent image selection based on time
- Creates variety between different entities
- Improves performance by reducing database operations
- Makes image rotation more predictable and maintainable