### PR TITLE
tiny bugs

### DIFF
--- a/lib/trivia_advisor_web/live/admin/duplicate_review.html.heex
+++ b/lib/trivia_advisor_web/live/admin/duplicate_review.html.heex
@@ -508,7 +508,7 @@
               phx-click="merge_venues" 
               phx-value-primary_id={@venue1.id} 
               phx-value-secondary_id={@venue2.id}
-              data-confirm={"Merge Venue B into Venue A?#{if length(@field_overrides || []) > 0, do: "\n\n• Field overrides: #{Enum.join(@field_overrides, ", ")}", else: ""}\n\n• Events will move to Venue A\n• Images will be combined (no duplicates)\n• Venue B will be soft-deleted\n• This cannot be undone"}
+              data-confirm={build_merge_confirmation_text(@venue1, @venue2, @field_overrides)}
               class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
             >
               ⬅️ Keep A, Merge B into A
@@ -517,7 +517,7 @@
               phx-click="merge_venues" 
               phx-value-primary_id={@venue2.id} 
               phx-value-secondary_id={@venue1.id}
-              data-confirm={"Merge Venue A into Venue B?#{if length(@field_overrides || []) > 0, do: "\n\n• Field overrides: #{Enum.join(@field_overrides, ", ")}", else: ""}\n\n• Events will move to Venue B\n• Images will be combined (no duplicates)\n• Venue A will be soft-deleted\n• This cannot be undone"}
+              data-confirm={build_merge_confirmation_text(@venue2, @venue1, @field_overrides)}
               class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
             >
               ➡️ Keep B, Merge A into B


### PR DESCRIPTION
### TL;DR

Enhanced venue duplicate review functionality with improved security and user experience.

### What changed?

- Added security for field overrides by validating against an allowed list (`@allowed_override_fields`) and handling invalid fields gracefully
- Added race condition prevention to reject duplicate venues by checking if they've already been reviewed
- Improved merge confirmation dialogs with more descriptive text that includes venue names
- Created a helper function `build_merge_confirmation_text` to generate consistent confirmation messages
- Replaced generic "Venue A" and "Venue B" labels with actual venue names in confirmation dialogs

### How to test?

1. Navigate to the admin duplicate review page
2. Try to override fields both in and out of the allowed list
3. Attempt to reject a duplicate that's already been processed
4. Test the merge functionality and verify the confirmation dialog shows proper venue names
5. Verify field overrides are correctly displayed in the confirmation dialog

### Why make this change?

These changes improve security by preventing manipulation of unauthorized fields and enhance the user experience by providing clearer confirmation messages with actual venue names. The race condition prevention ensures that two admins can't process the same duplicate simultaneously, maintaining data integrity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and validation when toggling field overrides, ensuring only allowed fields can be overridden and providing clear error messages for invalid actions.
  - Prevented race conditions when rejecting duplicates by verifying their status before processing, with user feedback if already reviewed.

- **Refactor**
  - Centralized and standardized the merge confirmation dialog text, ensuring consistent messaging when merging venues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->