### PR TITLE
more stuff

### DIFF
--- a/lib/trivia_advisor_web/live/admin/duplicate_review.ex
+++ b/lib/trivia_advisor_web/live/admin/duplicate_review.ex
@@ -488,8 +488,8 @@ defmodule TriviaAdvisorWeb.Live.Admin.DuplicateReview do
     offset = (page - 1) * 50
 
     base_query = from fd in VenueFuzzyDuplicate,
-      join: v1 in Venue, on: v1.id == fd.venue1_id,
-      join: v2 in Venue, on: v2.id == fd.venue2_id,
+      join: v1 in TriviaAdvisor.Locations.Venue, on: v1.id == fd.venue1_id,
+      join: v2 in TriviaAdvisor.Locations.Venue, on: v2.id == fd.venue2_id,
       where: fd.status == "pending",
       where: is_nil(v1.deleted_at),
       where: is_nil(v2.deleted_at),
@@ -536,8 +536,8 @@ defmodule TriviaAdvisorWeb.Live.Admin.DuplicateReview do
   # Count fuzzy duplicate pairs for pagination
   defp count_fuzzy_duplicate_pairs(filter_type) do
     base_query = from fd in VenueFuzzyDuplicate,
-      join: v1 in Venue, on: v1.id == fd.venue1_id,
-      join: v2 in Venue, on: v2.id == fd.venue2_id,
+      join: v1 in TriviaAdvisor.Locations.Venue, on: v1.id == fd.venue1_id,
+      join: v2 in TriviaAdvisor.Locations.Venue, on: v2.id == fd.venue2_id,
       where: fd.status == "pending",
       where: is_nil(v1.deleted_at),
       where: is_nil(v2.deleted_at)


### PR DESCRIPTION
### TL;DR

Updated venue join references in the duplicate review module to use fully qualified module paths.

### What changed?

Modified the `duplicate_review.ex` file to use fully qualified module paths (`TriviaAdvisor.Locations.Venue`) instead of just `Venue` in the join clauses of two Ecto queries:
- Updated the query in `get_fuzzy_duplicate_pairs/2`
- Updated the query in `count_fuzzy_duplicate_pairs/1`

### How to test?

1. Navigate to the admin duplicate review page
2. Verify that venue fuzzy duplicates load correctly
3. Test pagination to ensure count functionality works
4. Confirm that filtering works as expected

### Why make this change?

This change improves code clarity and prevents potential module resolution issues by using fully qualified paths. It ensures the correct `Venue` module is referenced, avoiding any ambiguity if multiple modules with the same name exist in different namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Internal updates to improve query reliability; no visible changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->