### PR TITLE
fixes for final

### DIFF
--- a/lib/trivia_advisor_web/live/venue/helpers/venue_show_helpers.ex
+++ b/lib/trivia_advisor_web/live/venue/helpers/venue_show_helpers.ex
@@ -67,6 +67,7 @@ defmodule TriviaAdvisorWeb.Live.Venue.Helpers.VenueShowHelpers do
       similar_venues = TriviaAdvisor.Repo.all(
         from v in TriviaAdvisor.Locations.Venue,
         where: like(v.slug, ^"#{base_slug}%") and is_nil(v.deleted_at),
+        order_by: [asc: v.slug],
         limit: 1
       )
 


### PR DESCRIPTION
### TL;DR

Added ordering by slug when querying similar venues.

### What changed?

Added an `order_by: [asc: v.slug]` clause to the query that fetches similar venues in the `venue_show_helpers.ex` file. This ensures that similar venues are returned in a consistent, alphabetical order by their slug.

### How to test?

1. Navigate to a venue page where similar venues might be displayed
2. Verify that similar venues appear in alphabetical order by slug
3. Create test venues with similar slugs and confirm they're ordered correctly

### Why make this change?

Without explicit ordering, database query results can be returned in an inconsistent order. Adding this ordering clause ensures deterministic results when fetching similar venues, which improves predictability and consistency in the user interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that similar venues are consistently selected in ascending order by name, providing more predictable results when viewing venue matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->