### PR TITLE
fix images

### DIFF
--- a/lib/trivia_advisor/services/venue_merge_service.ex
+++ b/lib/trivia_advisor/services/venue_merge_service.ex
@@ -487,9 +487,9 @@ defmodule TriviaAdvisor.Services.VenueMergeService do
     primary_images = primary || []
     secondary_images = secondary || []
 
-    # Combine and deduplicate images by URL to avoid near-duplicates
+    # Combine and deduplicate images by original_url to avoid near-duplicates
     combined = (primary_images ++ secondary_images)
-    |> Enum.uniq_by(&Map.get(&1, "url"))  # Deduplicate by URL, not entire map
+    |> Enum.uniq_by(&Map.get(&1, "original_url"))  # Deduplicate by original_url, not entire map
 
     case combined do
       [] -> primary  # Keep original if somehow no images


### PR DESCRIPTION
### TL;DR

Updated image deduplication logic in venue merging to use `original_url` instead of `url`.

### What changed?

Modified the `VenueMergeService` to deduplicate venue images based on the `original_url` field rather than the `url` field when merging venues. This includes updating both the code and the corresponding comment to reflect this change.

### How to test?

1. Merge two venues that have images with the same `original_url` but different `url` values
2. Verify that only one instance of each image (based on `original_url`) appears in the merged venue
3. Confirm that the deduplication properly preserves image data

### Why make this change?

Using `original_url` for deduplication is more accurate than using `url` since it represents the source image. This prevents near-duplicate images from being included in merged venues, which could happen if different sized versions or formats of the same original image were being treated as distinct images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deduplication of venue images to prevent duplicates based on the original image URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->